### PR TITLE
ci: rename status check to `verify`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
     branches: [main]
   pull_request:
 jobs:
-  check:
+  verify:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Renames the CI job `check` → `verify` so the PR status check has a descriptive name. Ruleset updated to require `verify`.