### PR TITLE
feat: implement OAuth 2.0 authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,15 @@
 # ServiceNow instance
 SN_INSTANCE=https://your-instance.service-now.com
+
+# Basic auth (default)
 SN_USERNAME=admin
 SN_PASSWORD=...
+
+# OAuth (set SN_AUTH_TYPE=oauth and fill in client credentials)
+# SN_AUTH_TYPE=oauth
+# SN_CLIENT_ID=...
+# SN_CLIENT_SECRET=...
+# SN_GRANT_TYPE=password        # or client_credentials
 
 # Server options
 PORT=3000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,9 +56,16 @@ No hook enforces this — it is entirely your responsibility. Skipping step 1 me
 | Variable | Required | Description |
 |---|---|---|
 | `SN_INSTANCE` | ✅ | `https://dev12345.service-now.com` |
+| `SN_AUTH_TYPE` | ❌ | `basic` (default) or `oauth` |
 | `SN_USERNAME` | ✅ | ServiceNow username |
 | `SN_PASSWORD` | ✅ | ServiceNow password |
+| `SN_CLIENT_ID` | ✅ | OAuth client ID from Application Registry |
+| `SN_CLIENT_SECRET` | ✅ | OAuth client secret |
+| `SN_GRANT_TYPE` | ❌ | `password` (default) or `client_credentials` |
 | `PORT` | ❌ | HTTP port (default `3000`) |
 | `TRANSPORT` | ❌ | `http` (default) or `stdio` |
 | `CREDENTIAL_PROVIDER` | ❌ | `env` (dev default) or `header` (gateway mode) |
 | `GATEWAY_SECRET` | ❌ | Required when `CREDENTIAL_PROVIDER=header` |
+
+¹ Required when `SN_AUTH_TYPE=basic` or `SN_GRANT_TYPE=password`  
+² Required when `SN_AUTH_TYPE=oauth`

--- a/README.md
+++ b/README.md
@@ -125,20 +125,73 @@ Or run from source (no build step needed):
 
 ## Configuration
 
+Copy `.env.example` to `.env` to configure.
+
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `SN_INSTANCE` | ✅ | — | Full URL e.g. `https://dev12345.service-now.com` |
+| `SN_AUTH_TYPE` | ❌ | `basic` | `basic` or `oauth` |
 | `SN_USERNAME` | ✅ | — | ServiceNow username |
 | `SN_PASSWORD` | ✅ | — | ServiceNow password |
+| `SN_CLIENT_ID` | ✅ | — | OAuth client ID from Application Registry |
+| `SN_CLIENT_SECRET` | ✅ | — | OAuth client secret |
+| `SN_GRANT_TYPE` | ❌ | `password` | `password` or `client_credentials` |
 | `PORT` | ❌ | `3000` | HTTP port |
 | `TRANSPORT` | ❌ | `http` | `http` or `stdio` |
 | `CREDENTIAL_PROVIDER` | ❌ | `env` | `env` (dev) or `header` (gateway mode) |
 | `GATEWAY_SECRET` | ❌ | — | Required when `CREDENTIAL_PROVIDER=header` |
 | `ALLOWED_ORIGIN` | ❌ | `*` in dev | CORS origin for HTTP transport |
 
-Copy `.env.example` to `.env` to configure.
+¹ Required when `SN_AUTH_TYPE=basic` or `SN_GRANT_TYPE=password`  
+² Required when `SN_AUTH_TYPE=oauth`
 
 > **Free PDI:** Don't have a ServiceNow instance? Get a free Personal Developer Instance at [developer.servicenow.com](https://developer.servicenow.com).
+
+---
+
+## Authentication
+
+### Basic auth (default)
+
+```bash
+SN_INSTANCE=https://dev12345.service-now.com
+SN_USERNAME=admin
+SN_PASSWORD=your-password
+```
+
+### OAuth 2.0
+
+Supports **password** (ROPC) and **client_credentials** grant types. Tokens are requested automatically, cached in memory, and refreshed before expiry. A 401 response triggers a transparent token refresh and retry.
+
+**Password grant** — user context preserved, works on PDIs:
+
+```bash
+SN_INSTANCE=https://dev12345.service-now.com
+SN_AUTH_TYPE=oauth
+SN_GRANT_TYPE=password
+SN_CLIENT_ID=your-client-id
+SN_CLIENT_SECRET=your-client-secret
+SN_USERNAME=admin
+SN_PASSWORD=your-password
+```
+
+**Client credentials** — service-to-service, no user credentials needed:
+
+```bash
+SN_INSTANCE=https://dev12345.service-now.com
+SN_AUTH_TYPE=oauth
+SN_GRANT_TYPE=client_credentials
+SN_CLIENT_ID=your-client-id
+SN_CLIENT_SECRET=your-client-secret
+```
+
+**ServiceNow setup:**
+
+1. Navigate to **System OAuth → Application Registry**
+2. Click **New** → **Create an OAuth API endpoint for external clients**
+3. Set a name, note the generated **Client ID** and **Client Secret**
+4. Set **Accessible from** to `All application scopes`
+5. Add the values to your `.env`
 
 ---
 
@@ -235,7 +288,6 @@ For production self-hosting:
 ## Roadmap
 
 - **Multi-instance support** — named instances in config (`dev`, `staging`, `prod`), switchable per tool call or via a `switch_instance` tool
-- **OAuth 2.0 auth** — client credentials and auth-code flows for ServiceNow instances with SSO
 - **ITSM tools** — incident, change, problem read/write
 - **Generic table tools** — `query_table`, `get_record`, `create_record`, `update_record` for any table not covered by curated tools
 

--- a/src/auth/provider.test.ts
+++ b/src/auth/provider.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { EnvCredentialProvider, HeaderCredentialProvider } from './provider.js';
 
 const CREDS = {
+  authType: 'basic' as const,
   instanceUrl: 'https://dev12345.service-now.com',
   username: 'admin',
   password: 'secret',
@@ -84,6 +85,85 @@ describe('HeaderCredentialProvider', () => {
         'x-gateway-secret': SECRET,
         'x-sn-instance': CREDS.instanceUrl,
         // username and password missing
+      }),
+    );
+    expect(result).toMatchObject({ ok: false, status: 400 });
+  });
+
+  it('resolves an OAuth password-grant config', async () => {
+    const provider = new HeaderCredentialProvider(SECRET);
+    const result = await provider.resolve(
+      makeReq({
+        'x-gateway-secret': SECRET,
+        'x-sn-auth-type': 'oauth',
+        'x-sn-grant-type': 'password',
+        'x-sn-instance': CREDS.instanceUrl,
+        'x-sn-client-id': 'client-id',
+        'x-sn-client-secret': 'client-secret',
+        'x-sn-username': CREDS.username,
+        'x-sn-password': CREDS.password,
+      }),
+    );
+    expect(result).toEqual({
+      ok: true,
+      credentials: {
+        authType: 'oauth',
+        grantType: 'password',
+        instanceUrl: CREDS.instanceUrl,
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+        username: CREDS.username,
+        password: CREDS.password,
+      },
+    });
+  });
+
+  it('resolves an OAuth client_credentials config without user fields', async () => {
+    const provider = new HeaderCredentialProvider(SECRET);
+    const result = await provider.resolve(
+      makeReq({
+        'x-gateway-secret': SECRET,
+        'x-sn-auth-type': 'oauth',
+        'x-sn-grant-type': 'client_credentials',
+        'x-sn-instance': CREDS.instanceUrl,
+        'x-sn-client-id': 'client-id',
+        'x-sn-client-secret': 'client-secret',
+      }),
+    );
+    expect(result).toEqual({
+      ok: true,
+      credentials: {
+        authType: 'oauth',
+        grantType: 'client_credentials',
+        instanceUrl: CREDS.instanceUrl,
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+      },
+    });
+  });
+
+  it('rejects an OAuth password grant missing user credentials', async () => {
+    const provider = new HeaderCredentialProvider(SECRET);
+    const result = await provider.resolve(
+      makeReq({
+        'x-gateway-secret': SECRET,
+        'x-sn-auth-type': 'oauth',
+        'x-sn-instance': CREDS.instanceUrl,
+        'x-sn-client-id': 'client-id',
+        'x-sn-client-secret': 'client-secret',
+        // username/password missing for the default password grant
+      }),
+    );
+    expect(result).toMatchObject({ ok: false, status: 400 });
+  });
+
+  it('rejects an unsupported auth type', async () => {
+    const provider = new HeaderCredentialProvider(SECRET);
+    const result = await provider.resolve(
+      makeReq({
+        'x-gateway-secret': SECRET,
+        'x-sn-auth-type': 'magic',
+        'x-sn-instance': CREDS.instanceUrl,
       }),
     );
     expect(result).toMatchObject({ ok: false, status: 400 });

--- a/src/auth/provider.ts
+++ b/src/auth/provider.ts
@@ -1,6 +1,10 @@
 import { timingSafeEqual } from 'node:crypto';
 import type { IncomingMessage } from 'node:http';
-import type { ServiceNowConfig } from '../clients/servicenow.js';
+import {
+  formatConfigError,
+  type ServiceNowConfig,
+  serviceNowConfigSchema,
+} from '../config/sn-config.js';
 import { log } from '../logger.js';
 
 export type CredentialResult =
@@ -46,21 +50,24 @@ export class HeaderCredentialProvider implements CredentialProvider {
       };
     }
 
-    const instance = req.headers['x-sn-instance'] as string | undefined;
-    const username = req.headers['x-sn-username'] as string | undefined;
-    const password = req.headers['x-sn-password'] as string | undefined;
+    const result = serviceNowConfigSchema.safeParse({
+      authType: req.headers['x-sn-auth-type'] ?? 'basic',
+      grantType: req.headers['x-sn-grant-type'] ?? 'password',
+      instanceUrl: req.headers['x-sn-instance'],
+      clientId: req.headers['x-sn-client-id'],
+      clientSecret: req.headers['x-sn-client-secret'],
+      username: req.headers['x-sn-username'],
+      password: req.headers['x-sn-password'],
+    });
 
-    if (!instance || !username || !password) {
+    if (!result.success) {
       return {
         ok: false,
         status: 400,
-        error: 'missing ServiceNow credential headers',
+        error: `invalid ServiceNow credential headers: ${formatConfigError(result.error)}`,
       };
     }
 
-    return {
-      ok: true,
-      credentials: { instanceUrl: instance, username, password },
-    };
+    return { ok: true, credentials: result.data };
   }
 }

--- a/src/auth/strategy.test.ts
+++ b/src/auth/strategy.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BasicAuthConfig, OAuthConfig } from '../config/sn-config.js';
+import { createAuthStrategy } from './strategy.js';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const BASE_URL = 'https://dev99999.service-now.com';
+
+const BASIC: BasicAuthConfig = {
+  authType: 'basic',
+  instanceUrl: BASE_URL,
+  username: 'admin',
+  password: 'secret',
+};
+
+const OAUTH_PASSWORD: OAuthConfig = {
+  authType: 'oauth',
+  grantType: 'password',
+  instanceUrl: BASE_URL,
+  clientId: 'client-id',
+  clientSecret: 'client-secret',
+  username: 'admin',
+  password: 'secret',
+};
+
+const OAUTH_CLIENT_CREDS: OAuthConfig = {
+  authType: 'oauth',
+  grantType: 'client_credentials',
+  instanceUrl: BASE_URL,
+  clientId: 'client-id',
+  clientSecret: 'client-secret',
+};
+
+function tokenResponse(body: Record<string, unknown>, status = 200): Response {
+  return {
+    ok: status < 400,
+    status,
+    statusText: status < 400 ? 'OK' : 'Unauthorized',
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+/** Parse the form body that was POSTed on the Nth fetch call. */
+function tokenRequest(call = 0): URLSearchParams {
+  return new URLSearchParams(mockFetch.mock.calls[call][1].body as string);
+}
+
+describe('createAuthStrategy', () => {
+  beforeEach(() => mockFetch.mockReset());
+  afterEach(() => vi.clearAllMocks());
+
+  describe('basic auth', () => {
+    const strategy = createAuthStrategy(BASIC, BASE_URL);
+
+    it('returns a static Basic header without any network call', async () => {
+      const header = await strategy.authHeader();
+      const expected = `Basic ${Buffer.from('admin:secret').toString('base64')}`;
+      expect(header).toBe(expected);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('does not request a retry on 401', () => {
+      expect(strategy.onUnauthorized()).toBe(false);
+    });
+
+    it('exposes the configured username', () => {
+      expect(strategy.username()).toBe('admin');
+    });
+  });
+
+  describe('oauth password grant', () => {
+    it('fetches a token and returns a Bearer header', async () => {
+      mockFetch.mockResolvedValueOnce(
+        tokenResponse({ access_token: 'tok-1', expires_in: 1800 }),
+      );
+      const strategy = createAuthStrategy(OAUTH_PASSWORD, BASE_URL);
+
+      expect(await strategy.authHeader()).toBe('Bearer tok-1');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch.mock.calls[0][0]).toBe(`${BASE_URL}/oauth_token.do`);
+
+      const body = tokenRequest();
+      expect(body.get('grant_type')).toBe('password');
+      expect(body.get('client_id')).toBe('client-id');
+      expect(body.get('username')).toBe('admin');
+      expect(body.get('password')).toBe('secret');
+    });
+
+    it('caches the token across calls', async () => {
+      mockFetch.mockResolvedValueOnce(
+        tokenResponse({ access_token: 'tok-1', expires_in: 1800 }),
+      );
+      const strategy = createAuthStrategy(OAUTH_PASSWORD, BASE_URL);
+
+      await strategy.authHeader();
+      await strategy.authHeader();
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('shares a single token fetch across concurrent callers', async () => {
+      mockFetch.mockResolvedValueOnce(
+        tokenResponse({ access_token: 'tok-1', expires_in: 1800 }),
+      );
+      const strategy = createAuthStrategy(OAUTH_PASSWORD, BASE_URL);
+
+      const [a, b] = await Promise.all([
+        strategy.authHeader(),
+        strategy.authHeader(),
+      ]);
+
+      expect(a).toBe('Bearer tok-1');
+      expect(b).toBe('Bearer tok-1');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses the refresh token after onUnauthorized', async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          tokenResponse({
+            access_token: 'tok-1',
+            refresh_token: 'refresh-1',
+            expires_in: 1800,
+          }),
+        )
+        .mockResolvedValueOnce(
+          tokenResponse({ access_token: 'tok-2', expires_in: 1800 }),
+        );
+      const strategy = createAuthStrategy(OAUTH_PASSWORD, BASE_URL);
+
+      await strategy.authHeader();
+      expect(strategy.onUnauthorized()).toBe(true);
+      expect(await strategy.authHeader()).toBe('Bearer tok-2');
+
+      const refreshBody = tokenRequest(1);
+      expect(refreshBody.get('grant_type')).toBe('refresh_token');
+      expect(refreshBody.get('refresh_token')).toBe('refresh-1');
+    });
+
+    it('falls back to a full grant when refresh fails', async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          tokenResponse({
+            access_token: 'tok-1',
+            refresh_token: 'refresh-1',
+            expires_in: 1800,
+          }),
+        )
+        .mockResolvedValueOnce(tokenResponse({ error: 'bad' }, 401))
+        .mockResolvedValueOnce(
+          tokenResponse({ access_token: 'tok-3', expires_in: 1800 }),
+        );
+      const strategy = createAuthStrategy(OAUTH_PASSWORD, BASE_URL);
+
+      await strategy.authHeader();
+      strategy.onUnauthorized();
+      expect(await strategy.authHeader()).toBe('Bearer tok-3');
+
+      expect(tokenRequest(1).get('grant_type')).toBe('refresh_token');
+      expect(tokenRequest(2).get('grant_type')).toBe('password');
+    });
+  });
+
+  describe('oauth client_credentials grant', () => {
+    it('sends client_credentials without user fields', async () => {
+      mockFetch.mockResolvedValueOnce(
+        tokenResponse({ access_token: 'tok-1', expires_in: 1800 }),
+      );
+      const strategy = createAuthStrategy(OAUTH_CLIENT_CREDS, BASE_URL);
+
+      expect(await strategy.authHeader()).toBe('Bearer tok-1');
+      const body = tokenRequest();
+      expect(body.get('grant_type')).toBe('client_credentials');
+      expect(body.has('username')).toBe(false);
+      expect(body.has('password')).toBe(false);
+    });
+
+    it('reports an empty username (not tied to a user)', () => {
+      const strategy = createAuthStrategy(OAUTH_CLIENT_CREDS, BASE_URL);
+      expect(strategy.username()).toBe('');
+    });
+  });
+});

--- a/src/auth/strategy.ts
+++ b/src/auth/strategy.ts
@@ -1,0 +1,169 @@
+import { fetchWithTimeout, SnApiError } from '../clients/http.js';
+import type {
+  BasicAuthConfig,
+  OAuthConfig,
+  ServiceNowConfig,
+} from '../config/sn-config.js';
+import { log } from '../logger.js';
+
+/**
+ * Encapsulates how a request is authenticated against ServiceNow.
+ * The client stays agnostic to whether that is Basic auth or OAuth.
+ */
+export interface AuthStrategy {
+  /** Authorization header value to send with each request. */
+  authHeader(): Promise<string>;
+  /**
+   * Called after a 401. Returns true if the failure may be transient and the
+   * request is worth retrying (e.g. an expired OAuth token was discarded),
+   * false if the credentials are simply wrong (Basic auth).
+   */
+  onUnauthorized(): boolean;
+  /** Authenticated username, or '' when not tied to a user (client_credentials). */
+  username(): string;
+}
+
+class BasicAuthStrategy implements AuthStrategy {
+  private readonly header: string;
+
+  constructor(private readonly config: BasicAuthConfig) {
+    this.header = `Basic ${Buffer.from(
+      `${config.username}:${config.password}`,
+    ).toString('base64')}`;
+  }
+
+  async authHeader(): Promise<string> {
+    return this.header;
+  }
+
+  onUnauthorized(): boolean {
+    return false;
+  }
+
+  username(): string {
+    return this.config.username;
+  }
+}
+
+interface OAuthTokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+}
+
+const TOKEN_ENDPOINT = '/oauth_token.do';
+const TOKEN_EXPIRY_SKEW_MS = 60_000;
+const DEFAULT_TOKEN_TTL_SECONDS = 1800;
+const TOKEN_REQUEST_TIMEOUT_MS = 30_000;
+
+type OAuthGrant = OAuthConfig['grantType'] | 'refresh_token';
+
+class OAuthStrategy implements AuthStrategy {
+  private accessToken: string | null = null;
+  private refreshToken: string | null = null;
+  private expiresAt = 0;
+  private inFlight: Promise<void> | null = null;
+
+  constructor(
+    private readonly baseUrl: string,
+    private readonly config: OAuthConfig,
+  ) {}
+
+  async authHeader(): Promise<string> {
+    return `Bearer ${await this.resolveToken()}`;
+  }
+
+  onUnauthorized(): boolean {
+    this.accessToken = null;
+    this.expiresAt = 0;
+    return true;
+  }
+
+  username(): string {
+    return this.config.grantType === 'password' ? this.config.username : '';
+  }
+
+  private async resolveToken(): Promise<string> {
+    if (
+      this.accessToken &&
+      Date.now() < this.expiresAt - TOKEN_EXPIRY_SKEW_MS
+    ) {
+      return this.accessToken;
+    }
+    if (!this.inFlight) {
+      this.inFlight = this.acquireToken().finally(() => {
+        this.inFlight = null;
+      });
+    }
+    await this.inFlight;
+    return this.accessToken as string;
+  }
+
+  private async acquireToken(): Promise<void> {
+    if (this.refreshToken) {
+      try {
+        await this.fetchToken('refresh_token');
+        return;
+      } catch (err) {
+        log('DBG', 'OAuth token refresh failed, falling back to full grant', {
+          error: String(err),
+        });
+      }
+    }
+    await this.fetchToken(this.config.grantType);
+  }
+
+  private async fetchToken(grant: OAuthGrant): Promise<void> {
+    const params = new URLSearchParams({
+      grant_type: grant,
+      client_id: this.config.clientId,
+      client_secret: this.config.clientSecret,
+    });
+
+    if (grant === 'refresh_token') {
+      if (!this.refreshToken) {
+        throw new Error('No refresh token available');
+      }
+      params.set('refresh_token', this.refreshToken);
+    } else if (this.config.grantType === 'password') {
+      params.set('username', this.config.username);
+      params.set('password', this.config.password);
+    }
+
+    const url = `${this.baseUrl}${TOKEN_ENDPOINT}`;
+    const response = await fetchWithTimeout(
+      url,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params.toString(),
+      },
+      TOKEN_REQUEST_TIMEOUT_MS,
+    );
+
+    if (!response.ok) {
+      throw new SnApiError(
+        response.status,
+        response.statusText,
+        await response.text(),
+        url,
+      );
+    }
+
+    const data = (await response.json()) as OAuthTokenResponse;
+    this.accessToken = data.access_token;
+    // ServiceNow may omit a fresh refresh_token on refresh; keep the existing one.
+    this.refreshToken = data.refresh_token ?? this.refreshToken;
+    this.expiresAt =
+      Date.now() + (data.expires_in ?? DEFAULT_TOKEN_TTL_SECONDS) * 1000;
+  }
+}
+
+export function createAuthStrategy(
+  config: ServiceNowConfig,
+  baseUrl: string,
+): AuthStrategy {
+  return config.authType === 'basic'
+    ? new BasicAuthStrategy(config)
+    : new OAuthStrategy(baseUrl, config);
+}

--- a/src/clients/http.ts
+++ b/src/clients/http.ts
@@ -1,0 +1,24 @@
+export class SnApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly statusText: string,
+    public readonly body: string,
+    public readonly url: string,
+  ) {
+    super(`ServiceNow API error ${status} ${statusText} on ${url}`);
+    this.name = 'SnApiError';
+  }
+}
+
+/** fetch() with an AbortController-backed timeout. */
+export async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  return fetch(url, { ...init, signal: controller.signal }).finally(() =>
+    clearTimeout(timer),
+  );
+}

--- a/src/clients/servicenow.test.ts
+++ b/src/clients/servicenow.test.ts
@@ -34,6 +34,7 @@ describe('ServiceNowClient', () => {
 
   beforeEach(() => {
     client = new ServiceNowClient({
+      authType: 'basic',
       instanceUrl: INSTANCE_URL,
       username: USERNAME,
       password: PASSWORD,
@@ -103,6 +104,7 @@ describe('ServiceNowClient', () => {
 
     it('strips trailing slash from instanceUrl', async () => {
       const trailingClient = new ServiceNowClient({
+        authType: 'basic',
         instanceUrl: `${INSTANCE_URL}/`,
         username: USERNAME,
         password: PASSWORD,
@@ -265,6 +267,49 @@ describe('ServiceNowClient', () => {
   describe('getUsername', () => {
     it('returns the configured username', () => {
       expect(client.getUsername()).toBe(USERNAME);
+    });
+  });
+
+  describe('OAuth requests', () => {
+    function rawOkResponse(obj: unknown) {
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => obj,
+        text: async () => JSON.stringify(obj),
+      };
+    }
+
+    it('re-authenticates and retries once on a 401', async () => {
+      const oauthClient = new ServiceNowClient({
+        authType: 'oauth',
+        grantType: 'password',
+        instanceUrl: INSTANCE_URL,
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+        username: USERNAME,
+        password: PASSWORD,
+      });
+
+      mockFetch
+        .mockResolvedValueOnce(
+          rawOkResponse({ access_token: 'tok-1', expires_in: 1800 }),
+        )
+        .mockResolvedValueOnce(errorResponse(401, 'Unauthorized', 'expired'))
+        .mockResolvedValueOnce(
+          rawOkResponse({ access_token: 'tok-2', expires_in: 1800 }),
+        )
+        .mockResolvedValueOnce(okResponse([{ number: { value: 'INC001' } }]));
+
+      const result = await oauthClient.listRecords('incident', 'active=true');
+
+      expect(result).toHaveLength(1);
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+      // The retried data request carries the freshly fetched bearer token.
+      expect(mockFetch.mock.calls[3][1].headers.Authorization).toBe(
+        'Bearer tok-2',
+      );
     });
   });
 

--- a/src/clients/servicenow.ts
+++ b/src/clients/servicenow.ts
@@ -1,45 +1,28 @@
+import { type AuthStrategy, createAuthStrategy } from '../auth/strategy.js';
+import type { ServiceNowConfig } from '../config/sn-config.js';
 import { isSysId } from '../tools/helpers.js';
 import type { SnReference } from '../types/servicenow.js';
+import { fetchWithTimeout, SnApiError } from './http.js';
 
-export class SnApiError extends Error {
-  constructor(
-    public readonly status: number,
-    public readonly statusText: string,
-    public readonly body: string,
-    public readonly url: string,
-  ) {
-    super(`ServiceNow API error ${status} ${statusText} on ${url}`);
-    this.name = 'SnApiError';
-  }
-}
+export { SnApiError } from './http.js';
 
 interface SnTableResponse<T> {
   result: T;
 }
 
-export interface ServiceNowConfig {
-  instanceUrl: string;
-  username: string;
-  password: string;
-}
-
 export class ServiceNowClient {
   private readonly baseUrl: string;
-  private readonly authHeader: string;
-  private readonly _username: string;
+  private readonly auth: AuthStrategy;
   private cachedInstanceSettings?: { timezone: string };
 
   constructor(config: ServiceNowConfig) {
     // Normalise: strip trailing slash
     this.baseUrl = config.instanceUrl.replace(/\/$/, '');
-    this._username = config.username;
-    this.authHeader =
-      'Basic ' +
-      Buffer.from(`${config.username}:${config.password}`).toString('base64');
+    this.auth = createAuthStrategy(config, this.baseUrl);
   }
 
   getUsername(): string {
-    return this._username;
+    return this.auth.username();
   }
 
   private async request<T>(
@@ -49,6 +32,7 @@ export class ServiceNowClient {
       method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
       body?: unknown;
       timeoutMs?: number;
+      isRetry?: boolean;
     } = {},
   ): Promise<T> {
     const url = new URL(`${this.baseUrl}/api/now${path}`);
@@ -61,20 +45,35 @@ export class ServiceNowClient {
       url.searchParams.set(key, value);
     }
 
-    const { method = 'GET', body, timeoutMs = 30_000 } = options;
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const {
+      method = 'GET',
+      body,
+      timeoutMs = 30_000,
+      isRetry = false,
+    } = options;
 
-    const response = await fetch(url.toString(), {
-      method,
-      signal: controller.signal,
-      headers: {
-        Authorization: this.authHeader,
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
+    const response = await fetchWithTimeout(
+      url.toString(),
+      {
+        method,
+        headers: {
+          Authorization: await this.auth.authHeader(),
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: body !== undefined ? JSON.stringify(body) : undefined,
       },
-      body: body !== undefined ? JSON.stringify(body) : undefined,
-    }).finally(() => clearTimeout(timer));
+      timeoutMs,
+    );
+
+    if (response.status === 401 && !isRetry && this.auth.onUnauthorized()) {
+      return this.request<T>(path, params, {
+        method,
+        body,
+        timeoutMs,
+        isRetry: true,
+      });
+    }
 
     if (!response.ok) {
       const text = await response.text();

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -24,11 +24,15 @@ const transport = optional('TRANSPORT', 'http');
 const isDev = environment === 'development';
 const isStdio = transport === 'stdio';
 
-const snCredsPresent = !!(
-  process.env.SN_INSTANCE &&
-  process.env.SN_USERNAME &&
-  process.env.SN_PASSWORD
-);
+// Enum validity (basic|oauth, password|client_credentials) is enforced by the
+// ServiceNow config schema when credentials are actually built.
+const snAuthType = optional('SN_AUTH_TYPE', 'basic');
+
+const snCredsPresent =
+  !!process.env.SN_INSTANCE &&
+  (snAuthType === 'oauth'
+    ? !!(process.env.SN_CLIENT_ID && process.env.SN_CLIENT_SECRET)
+    : !!(process.env.SN_USERNAME && process.env.SN_PASSWORD));
 const defaultProvider: CredentialProviderType =
   (isDev || isStdio) && snCredsPresent ? 'env' : 'header';
 
@@ -41,6 +45,8 @@ if (!validProviders.includes(rawProvider as CredentialProviderType)) {
   process.exit(1);
 }
 
+const snGrantType = optional('SN_GRANT_TYPE', 'password');
+
 export const config = {
   port: optionalInt('PORT', 3000),
   transport,
@@ -52,6 +58,10 @@ export const config = {
     instance: optional('SN_INSTANCE', ''),
     username: optional('SN_USERNAME', ''),
     password: optional('SN_PASSWORD', ''),
+    authType: snAuthType as 'basic' | 'oauth',
+    clientId: optional('SN_CLIENT_ID', ''),
+    clientSecret: optional('SN_CLIENT_SECRET', ''),
+    grantType: snGrantType as 'password' | 'client_credentials',
   },
 
   credentialProvider: rawProvider as CredentialProviderType,

--- a/src/config/sn-config.ts
+++ b/src/config/sn-config.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+
+const instanceUrl = z.string().min(1, 'instanceUrl is required');
+const clientId = z.string().min(1, 'clientId is required');
+const clientSecret = z.string().min(1, 'clientSecret is required');
+const username = z.string().min(1, 'username is required');
+const password = z.string().min(1, 'password is required');
+
+const basicSchema = z.object({
+  authType: z.literal('basic'),
+  instanceUrl,
+  username,
+  password,
+});
+
+const oAuthPasswordSchema = z.object({
+  authType: z.literal('oauth'),
+  grantType: z.literal('password'),
+  instanceUrl,
+  clientId,
+  clientSecret,
+  username,
+  password,
+});
+
+const oAuthClientCredentialsSchema = z.object({
+  authType: z.literal('oauth'),
+  grantType: z.literal('client_credentials'),
+  instanceUrl,
+  clientId,
+  clientSecret,
+});
+
+/**
+ * Single source of truth for how ServiceNow is authenticated.
+ */
+export const serviceNowConfigSchema = z.union([
+  basicSchema,
+  oAuthPasswordSchema,
+  oAuthClientCredentialsSchema,
+]);
+
+export type BasicAuthConfig = z.infer<typeof basicSchema>;
+export type OAuthConfig =
+  | z.infer<typeof oAuthPasswordSchema>
+  | z.infer<typeof oAuthClientCredentialsSchema>;
+export type ServiceNowConfig = z.infer<typeof serviceNowConfigSchema>;
+
+/** Flatten a ZodError into a single human-readable line. */
+export function formatConfigError(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const path = issue.path.join('.');
+      return path ? `${path}: ${issue.message}` : issue.message;
+    })
+    .join('; ');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,9 +12,13 @@ import {
   EnvCredentialProvider,
   HeaderCredentialProvider,
 } from './auth/provider.js';
-import type { ServiceNowConfig } from './clients/servicenow.js';
 import { ServiceNowClient } from './clients/servicenow.js';
 import { config } from './config/config.js';
+import {
+  formatConfigError,
+  type ServiceNowConfig,
+  serviceNowConfigSchema,
+} from './config/sn-config.js';
 import { log } from './logger.js';
 import { sessionStore } from './session-store.js';
 import { registerBusinessRuleTools } from './tools/business-rule.js';
@@ -26,14 +30,32 @@ import { registerScriptIncludeTools } from './tools/script-include.js';
 import { registerUiPolicyTools } from './tools/ui-policy-write.js';
 import { registerUpdateSetTools } from './tools/update-sets.js';
 
+function buildSnConfig(): ServiceNowConfig {
+  const result = serviceNowConfigSchema.safeParse({
+    authType: config.sn.authType,
+    grantType: config.sn.grantType,
+    instanceUrl: config.sn.instance,
+    clientId: config.sn.clientId,
+    clientSecret: config.sn.clientSecret,
+    username: config.sn.username,
+    password: config.sn.password,
+  });
+
+  if (!result.success) {
+    log(
+      'ERR',
+      `Invalid ServiceNow configuration: ${formatConfigError(result.error)}`,
+    );
+    process.exit(1);
+  }
+
+  return result.data;
+}
+
 function createCredentialProvider(): CredentialProvider {
   switch (config.credentialProvider) {
     case 'env':
-      return new EnvCredentialProvider({
-        instanceUrl: config.sn.instance,
-        username: config.sn.username,
-        password: config.sn.password,
-      });
+      return new EnvCredentialProvider(buildSnConfig());
     case 'header': {
       if (!config.gatewaySecret) {
         log(
@@ -264,15 +286,7 @@ async function startHttpServer(): Promise<void> {
 }
 
 async function startStdioServer(): Promise<void> {
-  if (!config.sn.instance || !config.sn.username || !config.sn.password) {
-    log('ERR', 'STDIO mode requires SN_INSTANCE, SN_USERNAME, SN_PASSWORD');
-    process.exit(1);
-  }
-  const server = buildServer({
-    instanceUrl: config.sn.instance,
-    username: config.sn.username,
-    password: config.sn.password,
-  });
+  const server = buildServer(buildSnConfig());
   const transport = new StdioServerTransport();
   await server.connect(transport);
   log('INFO', 'Running in stdio mode');

--- a/src/tools/update-sets.ts
+++ b/src/tools/update-sets.ts
@@ -30,6 +30,17 @@ export function registerUpdateSetTools(
       try {
         const username = client.getUsername();
 
+        if (!username) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'Cannot resolve the current Update Set: the connection is not tied to a named user (e.g. OAuth client_credentials grant). Use basic auth or an OAuth password grant for this tool.',
+              },
+            ],
+          };
+        }
+
         const prefs = await client.listRecords<RawUserPreference>(
           'sys_user_preference',
           `name=sys_update_set^user.user_name=${username}`,


### PR DESCRIPTION
## What this changes

Adds OAuth 2.0 authentication alongside the existing basic auth. Users can now authenticate via the OAuth password (ROPC) or client_credentials grant type by setting `SN_AUTH_TYPE=oauth` in their `.env`.

Internal refactor to support this cleanly:
- **AuthStrategy abstraction** — `BasicAuthStrategy` and `OAuthStrategy` extracted to `src/auth/strategy.ts`, keeping `ServiceNowClient` auth-agnostic
- **Single-flight token fetch** — concurrent `Promise.all()` calls share one `/oauth_token.do` request instead of stampeding
- **zod discriminated union** (`src/config/sn-config.ts`) is now the single source of truth for config shapes, replacing four scattered validation blocks
- **Shared `fetchWithTimeout`** helper in `src/clients/http.ts` removes duplicated `AbortController` boilerplate
- **`get_current_update_set` bug fix** — returns a clear message instead of a broken `user.user_name=` query when running under `client_credentials` (no named user)
- OAuth refresh failures are now logged instead of silently swallowed

## How it was verified

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test` passing 
- [x] Basic auth exercised against a live PDI
- [x] OAuth password grant exercised against a live PDI

## Notes

`client_credentials` grant requires a system property to be enabled on the ServiceNow instance (`com.snc.platform_security.oauth.credential.grant.enabled`). It is not available on PDIs by default.