### PR TITLE
feat: document VALCHANGES operators inline in filter_condition schema

### DIFF
--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -972,7 +972,9 @@ const BusinessRuleBase = z.object({
         "Encoded query syntax, e.g. 'priority=1^active=true^category=hardware'. " +
         'Use this whenever the rule should only fire for records matching certain field values. ' +
         'NEVER use the condition field for field comparisons — put them here. ' +
-        'Use the servicenow-query-operators skill to look up the correct operator for each field type.',
+        "To fire only when a field changes, use the VALCHANGES operator: e.g. 'assignment_groupVALCHANGES'. " +
+        "To fire when a field changes to a specific value: 'assignment_groupCHANGESTO<sys_id>'. " +
+        "To fire when a field changes from a specific value: 'assignment_groupCHANGESFROM<sys_id>'.",
     ),
   role_conditions: z
     .string()


### PR DESCRIPTION
## What this changes

Removes the reference to the external servicenow-query-operators skill from the filter_condition field description. Documents the correct change-detection operators (VALCHANGES, CHANGESTO, CHANGESFROM) directly in the schema so the tool is self-contained and does not depend on external skills to produce valid encoded queries.

Closes #

## How it was verified

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test` passing
- [x] Exercised against a live ServiceNow PDI (for tool changes)

## Notes

Anything reviewers should know — trade-offs, follow-ups, breaking changes.
