### PR TITLE
feat: add background script and fix script execution tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Built and maintained by **Veldev** — an AI assistant for ServiceNow developers
 
 ## Features
 
-29 tools across 8 domains:
+33 tools across 10 domains:
 
 | Domain | What it covers |
 |---|---|
@@ -23,6 +23,8 @@ Built and maintained by **Veldev** — an AI assistant for ServiceNow developers
 | **Script includes** | Create reusable server-side script includes |
 | **Business rules** | Create business rules with before/after/async modes |
 | **Update sets** | List, switch, and export update sets |
+| **Background scripts** | Schedule server-side JavaScript snippets via `sys_trigger` |
+| **Fix scripts** | Create, update, and run `sys_script_fix` records — stored server-side scripts for data and config repairs |
 
 
 ---
@@ -209,6 +211,10 @@ Create a new catalog item called "VPN Access Request" with a text variable for b
 Create a business rule on incident that sets priority to 1 when impact and urgency are both 1
 
 Create a record producer called "New Hire Equipment" that generates an sc_req_item record, with a pre-insert script that maps the selected laptop model to the item field
+
+Create a fix script called "Backfill Incident SLAs" that queries all incidents missing an SLA and sets a default one
+
+Run the fix script with sys_id 18f9eee1c3d1479043e1fc0d0501315e
 ```
 
 ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,10 +21,12 @@ import {
 } from './config/sn-config.js';
 import { log } from './logger.js';
 import { sessionStore } from './session-store.js';
+import { registerBackgroundScriptTools } from './tools/background-script.js';
 import { registerBusinessRuleTools } from './tools/business-rule.js';
 import { registerCatalogClientScriptTools } from './tools/catalog-client-script.js';
 import { registerCatalogReadTools } from './tools/catalog-read.js';
 import { registerCatalogWriteTools } from './tools/catalog-write.js';
+import { registerFixScriptTools } from './tools/fix-script.js';
 import { registerRecordProducerTools } from './tools/record-producer.js';
 import { registerScriptIncludeTools } from './tools/script-include.js';
 import { registerUiPolicyTools } from './tools/ui-policy-write.js';
@@ -304,6 +306,8 @@ function buildServer(credentials: ServiceNowConfig): McpServer {
   registerScriptIncludeTools(server, snClient);
   registerBusinessRuleTools(server, snClient);
   registerUpdateSetTools(server, snClient);
+  registerBackgroundScriptTools(server, snClient);
+  registerFixScriptTools(server, snClient);
 
   return server;
 }

--- a/src/tools/background-script.test.ts
+++ b/src/tools/background-script.test.ts
@@ -1,0 +1,113 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ServiceNowClient } from '../clients/servicenow.js';
+import { SnApiError } from '../clients/servicenow.js';
+import { buildTestPair, firstText } from '../tests/helpers.js';
+import { registerBackgroundScriptTools } from '../tools/background-script.js';
+
+const TRIGGER_SYS_ID = 'aaaa1111bbbb2222aaaa1111bbbb2222';
+const TRIGGER_NAME = 'MCP_Script_1717600000000';
+const NEXT_ACTION = '05/06/2026 10:00:01';
+
+function buildMockClient(): ServiceNowClient {
+  return {
+    executeBackgroundScriptTrigger: vi.fn().mockResolvedValue({
+      success: true,
+      trigger_sys_id: TRIGGER_SYS_ID,
+      trigger_name: TRIGGER_NAME,
+      next_action: NEXT_ACTION,
+      message: `Script scheduled to run at ${NEXT_ACTION} (UTC).`,
+    }),
+  } as unknown as ServiceNowClient;
+}
+
+describe('background-script tools (in-memory MCP)', () => {
+  let mcpClient: Client;
+  let teardown: () => Promise<void>;
+
+  beforeEach(async () => {
+    const pair = await buildTestPair(
+      registerBackgroundScriptTools,
+      buildMockClient(),
+    );
+    mcpClient = pair.mcpClient;
+    teardown = pair.teardown;
+  });
+
+  afterEach(async () => {
+    await teardown();
+  });
+
+  describe('execute_background_script', () => {
+    it('returns trigger_sys_id, trigger_name, and next_action on success', async () => {
+      const result = await mcpClient.callTool({
+        name: 'execute_background_script',
+        arguments: { script: 'gs.info("hello");' },
+      });
+      const text = firstText(result);
+      expect(text).toContain('scheduled successfully');
+      expect(text).toContain(TRIGGER_SYS_ID);
+      expect(text).toContain(TRIGGER_NAME);
+      expect(text).toContain(NEXT_ACTION);
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('calls executeBackgroundScriptTrigger with the provided script', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(
+        registerBackgroundScriptTools,
+        mockClient,
+      );
+      try {
+        const script = 'var gr = new GlideRecord("incident"); gr.query();';
+        await pair.mcpClient.callTool({
+          name: 'execute_background_script',
+          arguments: { script },
+        });
+        expect(mockClient.executeBackgroundScriptTrigger).toHaveBeenCalledWith(
+          script,
+        );
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('surfaces SnApiError as isError with status in message', async () => {
+      const errorClient = {
+        executeBackgroundScriptTrigger: vi
+          .fn()
+          .mockRejectedValue(
+            new SnApiError(
+              403,
+              'Forbidden',
+              'insufficient privileges',
+              'https://example.com',
+            ),
+          ),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(
+        registerBackgroundScriptTools,
+        errorClient,
+      );
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'execute_background_script',
+          arguments: { script: 'gs.info("x");' },
+        });
+        expect(result.isError).toBe(true);
+        const text = firstText(result);
+        expect(text).toContain('403');
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('rejects empty script with Zod validation error', async () => {
+      const result = await mcpClient.callTool({
+        name: 'execute_background_script',
+        arguments: { script: '' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+});

--- a/src/tools/background-script.ts
+++ b/src/tools/background-script.ts
@@ -1,0 +1,55 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ServiceNowClient } from '../clients/servicenow.js';
+import { handleError } from './helpers.js';
+import { BackgroundScriptExecute } from './schemas.js';
+
+export function registerBackgroundScriptTools(
+  server: McpServer,
+  client: ServiceNowClient,
+): void {
+  server.registerTool(
+    'execute_background_script',
+    {
+      title: 'Execute Background Script',
+      description: [
+        'Schedules a server-side JavaScript snippet to run as a background script',
+        'via a sys_trigger record. The script executes in the global scope and has',
+        'access to GlideRecord, gs, and all server-side APIs.',
+        '',
+        'The trigger fires approximately 1 second after creation. Use this to',
+        'run one-off maintenance scripts, data fixes, or debug snippets.',
+        '',
+        'Returns the trigger sys_id, name, and scheduled execution time.',
+      ].join('\n'),
+      inputSchema: BackgroundScriptExecute,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async ({ script }) => {
+      try {
+        const result = await client.executeBackgroundScriptTrigger(script);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: [
+                `Background script scheduled successfully.`,
+                ``,
+                `trigger_sys_id: ${result.trigger_sys_id}`,
+                `trigger_name:   ${result.trigger_name}`,
+                `next_action:    ${result.next_action}`,
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+}

--- a/src/tools/fix-script.test.ts
+++ b/src/tools/fix-script.test.ts
@@ -1,0 +1,360 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ServiceNowClient } from '../clients/servicenow.js';
+import { SnApiError } from '../clients/servicenow.js';
+import { buildTestPair, firstText } from '../tests/helpers.js';
+import { registerFixScriptTools } from '../tools/fix-script.js';
+
+const EXISTING_SYS_ID = 'aaaa1111bbbb2222aaaa1111bbbb2222';
+const NEW_SYS_ID = 'cccc3333dddd4444cccc3333dddd4444';
+const TRIGGER_SYS_ID = 'eeee5555ffff6666eeee5555ffff6666';
+const TRIGGER_NAME = 'MCP_Script_1717600000000';
+const NEXT_ACTION = '05/06/2026 10:00:01';
+
+const SAMPLE_SCRIPT = [
+  "var gr = new GlideRecord('incident');",
+  "gr.addQuery('active', true);",
+  'gr.query();',
+  'gs.info(gr.getRowCount());',
+].join('\n');
+
+function buildMockClient(): ServiceNowClient {
+  return {
+    listRecords: vi.fn().mockResolvedValue([]),
+    createRecord: vi.fn().mockResolvedValue({
+      sys_id: { value: NEW_SYS_ID, display_value: NEW_SYS_ID },
+      name: { value: 'Test Fix Script', display_value: 'Test Fix Script' },
+    }),
+    patchRecord: vi.fn().mockResolvedValue({}),
+    executeBackgroundScriptTrigger: vi.fn().mockResolvedValue({
+      success: true,
+      trigger_sys_id: TRIGGER_SYS_ID,
+      trigger_name: TRIGGER_NAME,
+      next_action: NEXT_ACTION,
+      message: `Script scheduled to run at ${NEXT_ACTION} (UTC).`,
+    }),
+  } as unknown as ServiceNowClient;
+}
+
+describe('fix-script tools (in-memory MCP)', () => {
+  let mcpClient: Client;
+  let teardown: () => Promise<void>;
+
+  beforeEach(async () => {
+    const pair = await buildTestPair(registerFixScriptTools, buildMockClient());
+    mcpClient = pair.mcpClient;
+    teardown = pair.teardown;
+  });
+
+  afterEach(async () => {
+    await teardown();
+  });
+
+  // ── create_fix_script ──────────────────────────────────────────────────────
+
+  describe('create_fix_script', () => {
+    it('creates the record and returns sys_id with metadata', async () => {
+      const result = await mcpClient.callTool({
+        name: 'create_fix_script',
+        arguments: { name: 'Test Fix Script', script: SAMPLE_SCRIPT },
+      });
+      const text = firstText(result);
+      expect(text).toContain('Fix Script created');
+      expect(text).toContain(NEW_SYS_ID);
+      expect(text).toContain('Test Fix Script');
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('sends the record to the sys_script_fix table', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerFixScriptTools, mockClient);
+      try {
+        await pair.mcpClient.callTool({
+          name: 'create_fix_script',
+          arguments: { name: 'MyFix', script: SAMPLE_SCRIPT },
+        });
+        expect(mockClient.createRecord).toHaveBeenCalledWith(
+          'sys_script_fix',
+          expect.objectContaining({ name: 'MyFix', script: SAMPLE_SCRIPT }),
+        );
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('serialises boolean fields as strings in the request body', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerFixScriptTools, mockClient);
+      try {
+        await pair.mcpClient.callTool({
+          name: 'create_fix_script',
+          arguments: {
+            name: 'MyFix',
+            script: SAMPLE_SCRIPT,
+            record_for_rollback: false,
+            before: true,
+            unloadable: true,
+          },
+        });
+        expect(mockClient.createRecord).toHaveBeenCalledWith(
+          'sys_script_fix',
+          expect.objectContaining({
+            record_for_rollback: 'false',
+            before: 'true',
+            unloadable: 'true',
+          }),
+        );
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('applies default values (record_for_rollback=true, before=false, unloadable=false)', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerFixScriptTools, mockClient);
+      try {
+        await pair.mcpClient.callTool({
+          name: 'create_fix_script',
+          arguments: { name: 'MyFix', script: SAMPLE_SCRIPT },
+        });
+        expect(mockClient.createRecord).toHaveBeenCalledWith(
+          'sys_script_fix',
+          expect.objectContaining({
+            record_for_rollback: 'true',
+            before: 'false',
+            unloadable: 'false',
+          }),
+        );
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('skips creation and returns existing sys_id when name already exists', async () => {
+      const idempotentClient = {
+        ...buildMockClient(),
+        listRecords: vi.fn().mockResolvedValue([
+          {
+            sys_id: {
+              value: EXISTING_SYS_ID,
+              display_value: EXISTING_SYS_ID,
+            },
+          },
+        ]),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(
+        registerFixScriptTools,
+        idempotentClient,
+      );
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'create_fix_script',
+          arguments: { name: 'Existing Fix', script: SAMPLE_SCRIPT },
+        });
+        const text = firstText(result);
+        expect(text).toContain('already exists');
+        expect(text).toContain(EXISTING_SYS_ID);
+        expect(idempotentClient.createRecord).not.toHaveBeenCalled();
+        expect(result.isError).toBeFalsy();
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('surfaces SnApiError as isError with HTTP status in message', async () => {
+      const errorClient = {
+        ...buildMockClient(),
+        createRecord: vi
+          .fn()
+          .mockRejectedValue(
+            new SnApiError(403, 'Forbidden', 'ACL', 'https://example.com'),
+          ),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(registerFixScriptTools, errorClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'create_fix_script',
+          arguments: { name: 'MyFix', script: SAMPLE_SCRIPT },
+        });
+        expect(result.isError).toBe(true);
+        expect(firstText(result)).toContain('403');
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('rejects empty script with a Zod validation error', async () => {
+      const result = await mcpClient.callTool({
+        name: 'create_fix_script',
+        arguments: { name: 'MyFix', script: '' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  // ── update_fix_script ──────────────────────────────────────────────────────
+
+  describe('update_fix_script', () => {
+    it('patches the record and reports success with the sys_id', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_fix_script',
+        arguments: { sys_id: EXISTING_SYS_ID, description: 'Updated' },
+      });
+      const text = firstText(result);
+      expect(text).toContain('updated successfully');
+      expect(text).toContain(EXISTING_SYS_ID);
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('only sends fields that were explicitly provided', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerFixScriptTools, mockClient);
+      try {
+        await pair.mcpClient.callTool({
+          name: 'update_fix_script',
+          arguments: { sys_id: EXISTING_SYS_ID, script: SAMPLE_SCRIPT },
+        });
+        const body = (mockClient.patchRecord as ReturnType<typeof vi.fn>).mock
+          .calls[0][2] as Record<string, unknown>;
+        expect(Object.keys(body)).toEqual(['script']);
+        expect(body.script).toBe(SAMPLE_SCRIPT);
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('serialises boolean fields as strings when provided', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerFixScriptTools, mockClient);
+      try {
+        await pair.mcpClient.callTool({
+          name: 'update_fix_script',
+          arguments: {
+            sys_id: EXISTING_SYS_ID,
+            record_for_rollback: false,
+            before: true,
+          },
+        });
+        expect(mockClient.patchRecord).toHaveBeenCalledWith(
+          'sys_script_fix',
+          EXISTING_SYS_ID,
+          expect.objectContaining({
+            record_for_rollback: 'false',
+            before: 'true',
+          }),
+        );
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('returns isError when sys_id is not a valid 32-char hex id', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_fix_script',
+        arguments: { sys_id: 'not-valid', description: 'x' },
+      });
+      expect(result.isError).toBe(true);
+      expect(firstText(result)).toContain('not a valid');
+    });
+
+    it('surfaces SnApiError as isError with HTTP status in message', async () => {
+      const errorClient = {
+        ...buildMockClient(),
+        patchRecord: vi
+          .fn()
+          .mockRejectedValue(
+            new SnApiError(
+              404,
+              'Not Found',
+              'no record',
+              'https://example.com',
+            ),
+          ),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(registerFixScriptTools, errorClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'update_fix_script',
+          arguments: { sys_id: EXISTING_SYS_ID, active: false },
+        });
+        expect(result.isError).toBe(true);
+        expect(firstText(result)).toContain('404');
+      } finally {
+        await pair.teardown();
+      }
+    });
+  });
+
+  // ── run_fix_script ─────────────────────────────────────────────────────────
+
+  describe('run_fix_script', () => {
+    it('schedules the fix script and returns trigger details', async () => {
+      const result = await mcpClient.callTool({
+        name: 'run_fix_script',
+        arguments: { sys_id: EXISTING_SYS_ID },
+      });
+      const text = firstText(result);
+      expect(text).toContain('execution scheduled');
+      expect(text).toContain(EXISTING_SYS_ID);
+      expect(text).toContain(TRIGGER_SYS_ID);
+      expect(text).toContain(TRIGGER_NAME);
+      expect(text).toContain(NEXT_ACTION);
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('passes a runner script containing the sys_id to executeBackgroundScriptTrigger', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerFixScriptTools, mockClient);
+      try {
+        await pair.mcpClient.callTool({
+          name: 'run_fix_script',
+          arguments: { sys_id: EXISTING_SYS_ID },
+        });
+        const calledScript = (
+          mockClient.executeBackgroundScriptTrigger as ReturnType<typeof vi.fn>
+        ).mock.calls[0][0] as string;
+        expect(calledScript).toContain(EXISTING_SYS_ID);
+        expect(calledScript).toContain('sys_script_fix');
+        expect(calledScript).toContain('GlideScopedEvaluator');
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('returns isError when sys_id is not a valid 32-char hex id', async () => {
+      const result = await mcpClient.callTool({
+        name: 'run_fix_script',
+        arguments: { sys_id: 'bad-id' },
+      });
+      expect(result.isError).toBe(true);
+      expect(firstText(result)).toContain('not a valid');
+    });
+
+    it('surfaces SnApiError as isError with HTTP status in message', async () => {
+      const errorClient = {
+        ...buildMockClient(),
+        executeBackgroundScriptTrigger: vi
+          .fn()
+          .mockRejectedValue(
+            new SnApiError(
+              403,
+              'Forbidden',
+              'insufficient privileges',
+              'https://example.com',
+            ),
+          ),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(registerFixScriptTools, errorClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'run_fix_script',
+          arguments: { sys_id: EXISTING_SYS_ID },
+        });
+        expect(result.isError).toBe(true);
+        expect(firstText(result)).toContain('403');
+      } finally {
+        await pair.teardown();
+      }
+    });
+  });
+});

--- a/src/tools/fix-script.ts
+++ b/src/tools/fix-script.ts
@@ -1,0 +1,243 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ServiceNowClient } from '../clients/servicenow.js';
+import type { SnReference } from '../types/servicenow.js';
+import { handleError, isSysId, resolveValue } from './helpers.js';
+import { FixScriptCreate, FixScriptRun, FixScriptUpdate } from './schemas.js';
+
+export function registerFixScriptTools(
+  server: McpServer,
+  client: ServiceNowClient,
+): void {
+  server.registerTool(
+    'create_fix_script',
+    {
+      title: 'Create Fix Script',
+      description: [
+        'Creates a sys_script_fix record in ServiceNow.',
+        '',
+        'Fix scripts are stored server-side JavaScript snippets that can be executed',
+        'on demand to repair data or configuration issues. Unlike background scripts,',
+        'fix scripts are persisted in the database and can be re-run at any time.',
+        '',
+        'Idempotent: if a fix script with the same name already exists, returns its',
+        'sys_id without creating a duplicate.',
+        '',
+        'Returns the sys_id and name of the created record.',
+      ].join('\n'),
+      inputSchema: FixScriptCreate,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({
+      name,
+      description,
+      script,
+      record_for_rollback,
+      before,
+      unloadable,
+    }) => {
+      try {
+        const existing = await client.listRecords<{ sys_id: SnReference }>(
+          'sys_script_fix',
+          `name=${name}`,
+          ['sys_id'],
+          1,
+        );
+
+        if (existing.length > 0) {
+          const sys_id = resolveValue(existing[0].sys_id);
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: [
+                  `Fix Script "${name}" already exists — skipped.`,
+                  `sys_id: ${sys_id}`,
+                ].join('\n'),
+              },
+            ],
+          };
+        }
+
+        const body: Record<string, unknown> = {
+          name,
+          script,
+          record_for_rollback: String(record_for_rollback),
+          before: String(before),
+          unloadable: String(unloadable),
+        };
+        if (description !== undefined) body.description = description;
+
+        const record = await client.createRecord<{
+          sys_id: SnReference;
+          name: SnReference;
+        }>('sys_script_fix', body);
+
+        const sys_id = resolveValue(record.sys_id);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: [
+                `Fix Script created.`,
+                ``,
+                `Name:                ${name}`,
+                `sys_id:              ${sys_id}`,
+                `record_for_rollback: ${record_for_rollback}`,
+                `before:              ${before}`,
+                `unloadable:          ${unloadable}`,
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    'update_fix_script',
+    {
+      title: 'Update Fix Script',
+      description: [
+        'Updates fields on an existing sys_script_fix record.',
+        '',
+        'Pass only the fields you want to change — omitted fields are left unchanged.',
+        'Requires the sys_id of the fix script to update.',
+      ].join('\n'),
+      inputSchema: FixScriptUpdate,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({
+      sys_id,
+      name,
+      description,
+      script,
+      record_for_rollback,
+      before,
+      unloadable,
+    }) => {
+      try {
+        if (!isSysId(sys_id)) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `"${sys_id}" is not a valid Fix Script sys_id.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const body: Record<string, unknown> = {};
+        if (name !== undefined) body.name = name;
+        if (description !== undefined) body.description = description;
+        if (script !== undefined) body.script = script;
+        if (record_for_rollback !== undefined)
+          body.record_for_rollback = String(record_for_rollback);
+        if (before !== undefined) body.before = String(before);
+        if (unloadable !== undefined) body.unloadable = String(unloadable);
+
+        await client.patchRecord<unknown>('sys_script_fix', sys_id, body);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: [
+                `Fix Script updated successfully.`,
+                ``,
+                `sys_id:         ${sys_id}`,
+                `Updated fields: ${Object.keys(body).join(', ') || 'none'}`,
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    'run_fix_script',
+    {
+      title: 'Run Fix Script',
+      description: [
+        'Executes a stored fix script (sys_script_fix) by scheduling it via a background trigger.',
+        '',
+        'Retrieves the fix script from the database by sys_id and runs its script body',
+        'using GlideScopedEvaluator via a sys_trigger that fires ~1 second after creation.',
+        '',
+        'Returns the trigger sys_id, name, and scheduled execution time.',
+      ].join('\n'),
+      inputSchema: FixScriptRun,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async ({ sys_id }) => {
+      try {
+        if (!isSysId(sys_id)) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `"${sys_id}" is not a valid Fix Script sys_id.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        // Build a runner that executes the stored fix script via GlideScopedEvaluator,
+        // matching the same mechanism ServiceNow uses when running a fix script from the UI.
+        const runnerScript = [
+          `var gr = new GlideRecord('sys_script_fix');`,
+          `if (gr.get('${sys_id}')) {`,
+          `    var evaluator = new GlideScopedEvaluator();`,
+          `    evaluator.evaluateScript(gr, 'script');`,
+          `} else {`,
+          `    gs.log('MCP run_fix_script: record not found — sys_id=${sys_id}', 'MCP');`,
+          `}`,
+        ].join('\n');
+
+        const result =
+          await client.executeBackgroundScriptTrigger(runnerScript);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: [
+                `Fix Script execution scheduled.`,
+                ``,
+                `fix_script_sys_id: ${sys_id}`,
+                `trigger_sys_id:    ${result.trigger_sys_id}`,
+                `trigger_name:      ${result.trigger_name}`,
+                `next_action:       ${result.next_action}`,
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+}

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -914,6 +914,92 @@ export const RecordProducerUpdate = RecordProducerBase.partial().extend({
     ),
 });
 
+// ── Fix Script ────────────────────────────────────────────────────────────────
+
+const FixScriptBase = z.object({
+  name: z.string().min(1).describe('Display name of the fix script.'),
+  description: z
+    .string()
+    .optional()
+    .describe('Description of what the fix script does.'),
+  script: z
+    .string()
+    .min(1)
+    .describe(
+      'Server-side JavaScript to execute. Runs in the global scope with full access to ' +
+        'GlideRecord, gs, and all server-side APIs. ' +
+        'Do NOT call current.update() — fix scripts run outside of a record context.',
+    ),
+  record_for_rollback: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true, a rollback record is created so the fix script can be reverted if needed.',
+    ),
+  before: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true, the fix script runs before the upgrade data migration. ' +
+        'Defaults to false (runs after the upgrade).',
+    ),
+  unloadable: z
+    .boolean()
+    .optional()
+    .describe('When true, the fix script can be unloaded from the instance.'),
+});
+
+export const FixScriptCreate = FixScriptBase.extend({
+  record_for_rollback: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe(
+      'When true, a rollback record is created so the fix script can be reverted. Defaults to true.',
+    ),
+  before: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(
+      'When true, the fix script runs before the upgrade data migration. Defaults to false.',
+    ),
+  unloadable: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(
+      'When true, the fix script can be unloaded from the instance. Defaults to false.',
+    ),
+});
+
+export const FixScriptUpdate = FixScriptBase.partial().extend({
+  sys_id: z
+    .string()
+    .min(1)
+    .describe('sys_id of the sys_script_fix record to update.'),
+});
+
+export const FixScriptRun = z.object({
+  sys_id: z
+    .string()
+    .min(1)
+    .describe('sys_id of the sys_script_fix record to execute.'),
+});
+
+// ── Background Script ─────────────────────────────────────────────────────────
+
+export const BackgroundScriptExecute = z.object({
+  script: z
+    .string()
+    .min(1)
+    .describe(
+      'Server-side JavaScript to execute as a background script. ' +
+        'Uses GlideRecord, gs, and other server-side APIs. ' +
+        'The script runs in the global scope — no function wrapper needed.',
+    ),
+});
+
 //Business Rule ───────────────────────────────────────────────────────────────
 
 const BusinessRuleBase = z.object({


### PR DESCRIPTION
## What this changes

- Adds tools for executing background scripts and managing fix scripts (`sys_script_fix`)
- Adds Zod schemas for all new tool inputs (`BackgroundScriptExecute`, `FixScript*`)
- Unit tests for all new tools

## How it was verified

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test` passing
- [x] Exercised against a live ServiceNow PDI (for tool changes)

## Notes

Anything reviewers should know — trade-offs, follow-ups, breaking changes.
