### PR TITLE
feat: add generic table CRUD tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Built and maintained by **Veldev** — an AI assistant for ServiceNow developers
 
 ## Features
 
-33 tools across 10 domains:
+37 tools across 11 domains:
 
 | Domain | What it covers |
 |---|---|
@@ -25,7 +25,6 @@ Built and maintained by **Veldev** — an AI assistant for ServiceNow developers
 | **Update sets** | List, switch, and export update sets |
 | **Background scripts** | Schedule server-side JavaScript snippets via `sys_trigger` |
 | **Fix scripts** | Create, update, and run `sys_script_fix` records — stored server-side scripts for data and config repairs |
-
 | **Generic Table CRUD** | Query, fetch, create, and update records in any ServiceNow table |
 
 ---
@@ -296,7 +295,6 @@ For production self-hosting:
 
 - **Multi-instance support** — named instances in config (`dev`, `staging`, `prod`), switchable per tool call or via a `switch_instance` tool
 - **ITSM tools** — incident, change, problem read/write
-- **Generic table tools** — `query_table`, `get_record`, `create_record`, `update_record` for any table not covered by curated tools
 
 Contributions welcome — see [CLAUDE.md](CLAUDE.md) for the architecture guide.
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Built and maintained by **Veldev** — an AI assistant for ServiceNow developers
 | **Background scripts** | Schedule server-side JavaScript snippets via `sys_trigger` |
 | **Fix scripts** | Create, update, and run `sys_script_fix` records — stored server-side scripts for data and config repairs |
 
+| **Generic Table CRUD** | Query, fetch, create, and update records in any ServiceNow table |
 
 ---
 

--- a/src/clients/servicenow.ts
+++ b/src/clients/servicenow.ts
@@ -109,6 +109,7 @@ export class ServiceNowClient {
     query: string,
     fields?: string[],
     limit = 100,
+    offset?: number,
   ): Promise<T[]> {
     const params: Record<string, string> = {
       sysparm_query: query,
@@ -116,6 +117,9 @@ export class ServiceNowClient {
     };
     if (fields?.length) {
       params.sysparm_fields = fields.join(',');
+    }
+    if (offset !== undefined) {
+      params.sysparm_offset = String(offset);
     }
     return this.request<T[]>(`/table/${table}`, params);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { registerCatalogWriteTools } from './tools/catalog-write.js';
 import { registerFixScriptTools } from './tools/fix-script.js';
 import { registerRecordProducerTools } from './tools/record-producer.js';
 import { registerScriptIncludeTools } from './tools/script-include.js';
+import { registerTableCrudTools } from './tools/table-crud.js';
 import { registerUiPolicyTools } from './tools/ui-policy-write.js';
 import { registerUpdateSetTools } from './tools/update-sets.js';
 
@@ -308,6 +309,7 @@ function buildServer(credentials: ServiceNowConfig): McpServer {
   registerUpdateSetTools(server, snClient);
   registerBackgroundScriptTools(server, snClient);
   registerFixScriptTools(server, snClient);
+  registerTableCrudTools(server, snClient);
 
   return server;
 }

--- a/src/tools/fix-script.ts
+++ b/src/tools/fix-script.ts
@@ -212,8 +212,6 @@ export function registerFixScriptTools(
           `if (gr.get('${sys_id}')) {`,
           `    var evaluator = new GlideScopedEvaluator();`,
           `    evaluator.evaluateScript(gr, 'script');`,
-          `} else {`,
-          `    gs.log('MCP run_fix_script: record not found — sys_id=${sys_id}', 'MCP');`,
           `}`,
         ].join('\n');
 

--- a/src/tools/table-crud.test.ts
+++ b/src/tools/table-crud.test.ts
@@ -1,0 +1,254 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ServiceNowClient } from '../clients/servicenow.js';
+import { SnApiError } from '../clients/servicenow.js';
+import { buildTestPair, firstText } from '../tests/helpers.js';
+import { registerTableCrudTools } from '../tools/table-crud.js';
+
+const TABLE = 'incident';
+const SYS_ID = 'a1111111111111111111111111111111';
+
+const RECORD = {
+  sys_id: { value: SYS_ID, display_value: SYS_ID },
+  number: { value: 'INC0010001', display_value: 'INC0010001' },
+  short_description: { value: 'Test incident', display_value: 'Test incident' },
+  state: { value: '1', display_value: 'New' },
+  assigned_to: {
+    value: 'abc123def456abc123def456abc12345',
+    display_value: 'John Doe',
+  },
+};
+
+function buildMockClient(): ServiceNowClient {
+  return {
+    listRecords: vi.fn().mockResolvedValue([RECORD]),
+    getRecord: vi.fn().mockResolvedValue(RECORD),
+    createRecord: vi.fn().mockResolvedValue(RECORD),
+    updateRecord: vi.fn().mockResolvedValue(RECORD),
+    patchRecord: vi.fn().mockResolvedValue(RECORD),
+  } as unknown as ServiceNowClient;
+}
+
+describe('table-crud tools (in-memory MCP)', () => {
+  let mcpClient: Client;
+  let mockClient: ServiceNowClient;
+  let teardown: () => Promise<void>;
+
+  beforeEach(async () => {
+    mockClient = buildMockClient();
+    const pair = await buildTestPair(registerTableCrudTools, mockClient);
+    mcpClient = pair.mcpClient;
+    teardown = pair.teardown;
+  });
+
+  afterEach(async () => {
+    await teardown();
+  });
+
+  describe('query_records', () => {
+    it('returns a single block containing JSON', async () => {
+      const result = await mcpClient.callTool({
+        name: 'query_records',
+        arguments: { table: TABLE, limit: 5 },
+      });
+      const r = result as { content: Array<unknown> };
+      expect(r.content).toHaveLength(1);
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(firstText(result));
+      expect(Array.isArray(parsed)).toBe(true);
+    });
+
+    it('passes encoded query and limit to client', async () => {
+      await mcpClient.callTool({
+        name: 'query_records',
+        arguments: { table: TABLE, query: 'state=1^priority=2', limit: 3 },
+      });
+      expect(mockClient.listRecords).toHaveBeenCalledWith(
+        TABLE,
+        'state=1^priority=2',
+        undefined,
+        3,
+        undefined,
+      );
+    });
+
+    it('passes offset to client when provided', async () => {
+      await mcpClient.callTool({
+        name: 'query_records',
+        arguments: { table: TABLE, limit: 10, offset: 20 },
+      });
+      expect(mockClient.listRecords).toHaveBeenCalledWith(
+        TABLE,
+        '',
+        undefined,
+        10,
+        20,
+      );
+    });
+
+    it('handles empty results — returns an empty JSON array', async () => {
+      const emptyClient = {
+        ...buildMockClient(),
+        listRecords: vi.fn().mockResolvedValue([]),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(registerTableCrudTools, emptyClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'query_records',
+          arguments: { table: TABLE },
+        });
+        expect((result as { content: Array<unknown> }).content).toHaveLength(1);
+        expect(JSON.parse(firstText(result))).toEqual([]);
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('raw JSON preserves SnReference objects intact', async () => {
+      const result = await mcpClient.callTool({
+        name: 'query_records',
+        arguments: { table: TABLE },
+      });
+      const json = JSON.parse(firstText(result));
+      expect(json[0].assigned_to).toEqual({
+        value: 'abc123def456abc123def456abc12345',
+        display_value: 'John Doe',
+      });
+    });
+  });
+
+  describe('get_record', () => {
+    it('returns a single block containing JSON', async () => {
+      const result = await mcpClient.callTool({
+        name: 'get_record',
+        arguments: { table: TABLE, sys_id: SYS_ID },
+      });
+      expect((result as { content: Array<unknown> }).content).toHaveLength(1);
+      expect(result.isError).toBeFalsy();
+      JSON.parse(firstText(result)); // must be valid JSON
+    });
+
+    it('passes fields correctly to client', async () => {
+      await mcpClient.callTool({
+        name: 'get_record',
+        arguments: {
+          table: TABLE,
+          sys_id: SYS_ID,
+          fields: ['sys_id', 'state'],
+        },
+      });
+      expect(mockClient.getRecord).toHaveBeenCalledWith(TABLE, SYS_ID, [
+        'sys_id',
+        'state',
+      ]);
+    });
+  });
+
+  describe('create_record', () => {
+    it('returns a single block containing sys_id, table name, and number', async () => {
+      const result = await mcpClient.callTool({
+        name: 'create_record',
+        arguments: { table: TABLE, data: { short_description: 'Test' } },
+      });
+      expect((result as { content: Array<unknown> }).content).toHaveLength(1);
+      expect(firstText(result)).toContain(TABLE);
+      expect(firstText(result)).toContain(SYS_ID);
+      expect(firstText(result)).toContain('INC0010001');
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  describe('update_record', () => {
+    it('calls updateRecord (PUT) when patch=false', async () => {
+      await mcpClient.callTool({
+        name: 'update_record',
+        arguments: {
+          table: TABLE,
+          sys_id: SYS_ID,
+          data: { state: '2' },
+          patch: false,
+        },
+      });
+      expect(mockClient.updateRecord).toHaveBeenCalledWith(TABLE, SYS_ID, {
+        state: '2',
+      });
+      expect(mockClient.patchRecord).not.toHaveBeenCalled();
+    });
+
+    it('calls patchRecord (PATCH) when patch=true', async () => {
+      await mcpClient.callTool({
+        name: 'update_record',
+        arguments: {
+          table: TABLE,
+          sys_id: SYS_ID,
+          data: { state: '2' },
+          patch: true,
+        },
+      });
+      expect(mockClient.patchRecord).toHaveBeenCalledWith(TABLE, SYS_ID, {
+        state: '2',
+      });
+      expect(mockClient.updateRecord).not.toHaveBeenCalled();
+    });
+
+    it('defaults to PATCH when patch is omitted', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_record',
+        arguments: { table: TABLE, sys_id: SYS_ID, data: { state: '2' } },
+      });
+      expect(mockClient.patchRecord).toHaveBeenCalledWith(TABLE, SYS_ID, {
+        state: '2',
+      });
+      expect(mockClient.updateRecord).not.toHaveBeenCalled();
+      expect((result as { content: Array<unknown> }).content).toHaveLength(1);
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns isError=true with status code when client throws SnApiError', async () => {
+      const errorClient = {
+        ...buildMockClient(),
+        listRecords: vi
+          .fn()
+          .mockRejectedValue(
+            new SnApiError(
+              500,
+              'Internal Server Error',
+              'Database error',
+              'https://example.com',
+            ),
+          ),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(registerTableCrudTools, errorClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'query_records',
+          arguments: { table: TABLE },
+        });
+        expect(result.isError).toBe(true);
+        expect(firstText(result)).toContain('500');
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('returns isError=true when get_record throws', async () => {
+      const errorClient = {
+        ...buildMockClient(),
+        getRecord: vi.fn().mockRejectedValue(new Error('record not found')),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(registerTableCrudTools, errorClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'get_record',
+          arguments: { table: TABLE, sys_id: SYS_ID },
+        });
+        expect(result.isError).toBe(true);
+        expect(firstText(result)).toContain('record not found');
+      } finally {
+        await pair.teardown();
+      }
+    });
+  });
+});

--- a/src/tools/table-crud.ts
+++ b/src/tools/table-crud.ts
@@ -1,0 +1,253 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { ServiceNowClient } from '../clients/servicenow.js';
+import type { SnReference } from '../types/servicenow.js';
+import { handleError } from './helpers.js';
+
+export function registerTableCrudTools(
+  server: McpServer,
+  client: ServiceNowClient,
+): void {
+  server.registerTool(
+    'query_records',
+    {
+      title: 'Query Records',
+      description: [
+        'Query any ServiceNow table using an encoded query string.',
+        '',
+        'WHEN TO USE: When you need to search or filter records in any table.',
+        'Use get_record to fetch a single known record by sys_id.',
+        '',
+        'Encoded query format: field=value^field2STARTSWITH prefix',
+        'Operators: =, !=, STARTSWITH, ENDSWITH, CONTAINS, IN, ISEMPTY, ISNOTEMPTY, >, <, >=, <=',
+        'Join conditions with ^ (AND) or ^OR (OR).',
+        'Example: "state=1^priority=2" returns records matching both conditions.',
+        '',
+        'Returns raw JSON. Reference fields have the shape { value, display_value };',
+        'use .value for the sys_id and .display_value for the human label.',
+      ].join('\n'),
+      inputSchema: {
+        table: z
+          .string()
+          .min(1)
+          .describe('ServiceNow table name (e.g. "incident", "sys_user").'),
+        query: z
+          .string()
+          .optional()
+          .describe(
+            'Encoded query string (e.g. "state=1^priority=2"). Leave empty to retrieve records without filtering.',
+          ),
+        fields: z
+          .array(z.string().min(1))
+          .optional()
+          .describe('Fields to return. Leave empty to return all fields.'),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .optional()
+          .default(20)
+          .describe(
+            'Maximum number of records to return (1–100). Defaults to 20.',
+          ),
+        offset: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            'Zero-based index of the first record to return. Use with limit for pagination.',
+          ),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({ table, query, fields, limit, offset }) => {
+      try {
+        const records = await client.listRecords<Record<string, unknown>>(
+          table,
+          query ?? '',
+          fields,
+          limit ?? 20,
+          offset,
+        );
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(records, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    'get_record',
+    {
+      title: 'Get Record',
+      description: [
+        'Fetch a single ServiceNow record by sys_id from any table.',
+        '',
+        'WHEN TO USE: When you know the exact sys_id of the record.',
+        'Use query_records when you need to search or filter.',
+        '',
+        'Returns raw JSON. Reference fields have the shape { value, display_value };',
+        'use .value for the sys_id and .display_value for the human label.',
+      ].join('\n'),
+      inputSchema: {
+        table: z
+          .string()
+          .min(1)
+          .describe('ServiceNow table name (e.g. "incident", "sys_user").'),
+        sys_id: z
+          .string()
+          .length(32)
+          .describe('32-character sys_id of the record to fetch.'),
+        fields: z
+          .array(z.string().min(1))
+          .optional()
+          .describe('Fields to return. Leave empty to return all fields.'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({ table, sys_id, fields }) => {
+      try {
+        const record = await client.getRecord<Record<string, unknown>>(
+          table,
+          sys_id,
+          fields,
+        );
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(record, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    'create_record',
+    {
+      title: 'Create Record',
+      description: [
+        'Create a new record in any ServiceNow table.',
+        '',
+        'WHEN TO USE: When you need to insert a new record into any table.',
+        'Field values are passed as plain strings; ServiceNow coerces types automatically.',
+        '',
+        'Returns the sys_id and, when present, the record number (e.g. INC0010001).',
+      ].join('\n'),
+      inputSchema: {
+        table: z
+          .string()
+          .min(1)
+          .describe(
+            'ServiceNow table name (e.g. "incident", "change_request").',
+          ),
+        data: z
+          .record(z.string(), z.unknown())
+          .describe(
+            'Fields and values for the new record. Field names must match the table schema.',
+          ),
+      },
+    },
+    async ({ table, data }) => {
+      try {
+        const created = await client.createRecord<{
+          sys_id: SnReference;
+          number?: SnReference;
+        }>(table, data);
+
+        const lines = [
+          `Created record in "${table}".`,
+          `sys_id: ${created.sys_id.value}`,
+        ];
+        if (created.number?.value)
+          lines.push(`number: ${created.number.value}`);
+
+        return {
+          content: [{ type: 'text' as const, text: lines.join('\n') }],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    'update_record',
+    {
+      title: 'Update Record',
+      description: [
+        'Update an existing ServiceNow record by sys_id.',
+        '',
+        'WHEN TO USE: When you need to modify fields on an existing record.',
+        '',
+        'patch=true  — PATCH: partial update, only the supplied fields are changed.',
+        'patch=false — PUT: full replacement. WARNING: fields NOT included in data',
+        '              may be reset to their default or empty values. Use with caution.',
+        '',
+        'Prefer patch=true unless a full replacement is intentional.',
+      ].join('\n'),
+      inputSchema: {
+        table: z
+          .string()
+          .min(1)
+          .describe('ServiceNow table name (e.g. "incident", "sys_user").'),
+        sys_id: z
+          .string()
+          .length(32)
+          .describe('32-character sys_id of the record to update.'),
+        data: z
+          .record(z.string(), z.unknown())
+          .describe('Fields and values to update.'),
+        patch: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            'true = PATCH (partial update, only supplied fields change). Defaults to true. ' +
+              'false = PUT (full replace — omitted fields may be cleared). Use with caution.',
+          ),
+      },
+    },
+    async ({ table, sys_id, data, patch }) => {
+      try {
+        if (patch) {
+          await client.patchRecord(table, sys_id, data);
+        } else {
+          await client.updateRecord(table, sys_id, data);
+        }
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Updated record in "${table}" (sys_id: ${sys_id}) using ${patch ? 'PATCH' : 'PUT'}.`,
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+}


### PR DESCRIPTION
## What this changes

Adds four tools that work against any ServiceNow table without schema knowledge:

- **`query_records`** — filter records with a ServiceNow encoded query, field selection, limit, and offset (pagination)
- **`get_record`** — fetch a single record by sys_id
- **`create_record`** — insert a new record; returns `sys_id` and `number` (e.g. `INC0010001`) when the table has one
- **`update_record`** — PATCH (partial, default) or PUT (full replace) by sys_id

Also extends `listRecords` in `ServiceNowClient` with an optional `offset` parameter for pagination.

## Design notes

- `patch` defaults to `true` (PATCH) — PUT must be opted into explicitly to avoid silent data loss
- Read tools return raw JSON from ServiceNow unchanged; reference fields keep their `{ value, display_value }` shape so sys_ids are directly chainable into other tools
- `create_record` types the response generic as `{ sys_id: SnReference; number?: SnReference }` — no ad-hoc type narrowing
- `offset` is a plain positional param on `listRecords` (consistent with `limit`), not wrapped in an options object

## How it was verified

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test` passing (201 tests)
- [x] Exercised against a live PDI: `query_records` (filters, pagination, ISEMPTY, CONTAINS, empty result, invalid table), `get_record` (field filter, 404), `create_record` (incident with `number`, `sys_properties` without), `update_record` (PATCH default, explicit PUT, 404, SN data policy 403)