### PR TITLE
feat: add ATF tools — create/update tests and suites, add/update steps, list step configs and schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Built and maintained by **Veldev** — an AI assistant for ServiceNow developers
 
 ## Features
 
-37 tools across 11 domains:
+48 tools across 12 domains:
 
 | Domain | What it covers |
 |---|---|
@@ -22,10 +22,11 @@ Built and maintained by **Veldev** — an AI assistant for ServiceNow developers
 | **Client scripts** | Create and manage catalog client scripts |
 | **Script includes** | Create reusable server-side script includes |
 | **Business rules** | Create business rules with before/after/async modes |
-| **Update sets** | List, switch, and export update sets |
+| **Update sets** | Show the active update set for the authenticated user |
 | **Background scripts** | Schedule server-side JavaScript snippets via `sys_trigger` |
 | **Fix scripts** | Create, update, and run `sys_script_fix` records — stored server-side scripts for data and config repairs |
 | **Generic Table CRUD** | Query, fetch, create, and update records in any ServiceNow table |
+| **ATF (Automated Test Framework)** | Create tests and suites, add and configure steps with cross-step output mapping, browse step configs and their input/output schemas |
 
 ---
 
@@ -215,6 +216,8 @@ Create a record producer called "New Hire Equipment" that generates an sc_req_it
 Create a fix script called "Backfill Incident SLAs" that queries all incidents missing an SLA and sets a default one
 
 Run the fix script with sys_id 18f9eee1c3d1479043e1fc0d0501315e
+
+Create an ATF test that submits the "VPN Access Request" catalog item and verifies the generated request record, mapping the record from the submit step into a server-side validation step
 ```
 
 ---

--- a/src/clients/servicenow.ts
+++ b/src/clients/servicenow.ts
@@ -25,6 +25,10 @@ export class ServiceNowClient {
     return this.auth.username();
   }
 
+  getInstanceUrl(): string {
+    return this.baseUrl;
+  }
+
   private async request<T>(
     path: string,
     params: Record<string, string> = {},

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import {
 } from './config/sn-config.js';
 import { log } from './logger.js';
 import { sessionStore } from './session-store.js';
+import { registerAtfTools } from './tools/atf.js';
 import { registerBackgroundScriptTools } from './tools/background-script.js';
 import { registerBusinessRuleTools } from './tools/business-rule.js';
 import { registerCatalogClientScriptTools } from './tools/catalog-client-script.js';
@@ -310,6 +311,7 @@ function buildServer(credentials: ServiceNowConfig): McpServer {
   registerBackgroundScriptTools(server, snClient);
   registerFixScriptTools(server, snClient);
   registerTableCrudTools(server, snClient);
+  registerAtfTools(server, snClient);
 
   return server;
 }

--- a/src/tools/atf.test.ts
+++ b/src/tools/atf.test.ts
@@ -559,6 +559,48 @@ describe('atf tools (in-memory MCP)', () => {
       expect(text).toContain('⚠ Assert input "assert_type" is empty');
       expect(text).toContain('record_successfully_inserted');
     });
+
+    it('does not patch order/active when an input is invalid', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerAtfTools, mockClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'update_atf_step',
+          arguments: {
+            sys_id: NEW_STEP_SYS,
+            order: 250,
+            inputs: [{ element: 'nonexistent', value: 'x' }],
+          },
+        });
+        expect(result.isError).toBe(true);
+        expect(firstText(result)).toContain('Unknown input element');
+        expect(mockClient.patchRecord).not.toHaveBeenCalled();
+        expect(
+          mockClient.executeBackgroundScriptTrigger,
+        ).not.toHaveBeenCalled();
+      } finally {
+        await pair.teardown();
+      }
+    });
+  });
+
+  describe('get_atf_test', () => {
+    it('returns isError on a non-sys_id without querying', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerAtfTools, mockClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'get_atf_test',
+          arguments: { sys_id: '0^ORDERBYname' },
+        });
+        expect(result.isError).toBe(true);
+        expect(firstText(result)).toContain('not a valid test sys_id');
+        expect(mockClient.getRecord).not.toHaveBeenCalled();
+        expect(mockClient.listRecords).not.toHaveBeenCalled();
+      } finally {
+        await pair.teardown();
+      }
+    });
   });
 
   describe('list_atf_tests', () => {

--- a/src/tools/atf.test.ts
+++ b/src/tools/atf.test.ts
@@ -1,0 +1,623 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ServiceNowClient } from '../clients/servicenow.js';
+import { SnApiError } from '../clients/servicenow.js';
+import { buildTestPair, firstText } from '../tests/helpers.js';
+import { registerAtfTools } from './atf.js';
+
+const ref = (v: string) => ({ value: v, display_value: v });
+
+const STEP_CONFIG_SYS = 'a0000000000000000000000000000001';
+const INPUT_TABLE_VAR = 'b0000000000000000000000000000001';
+const INPUT_FIELDS_VAR = 'c0000000000000000000000000000001';
+const INPUT_RECORD_VAR = 'd0000000000000000000000000000001';
+const TEST_SYS = 'e0000000000000000000000000000001';
+const SUITE_SYS = 'f0000000000000000000000000000001';
+const NEW_STEP_SYS = '10000000000000000000000000000001';
+const PRODUCER_STEP_SYS = '20000000000000000000000000000001';
+const NEW_RECORD_SYS = '30000000000000000000000000000001';
+
+const INPUT_DEFS = [
+  {
+    sys_id: ref(INPUT_TABLE_VAR),
+    element: ref('table'),
+    label: ref('Table'),
+    internal_type: ref('table_name'),
+    mandatory: ref('true'),
+    order: ref('100'),
+    reference: ref(''),
+    attributes: ref(''),
+  },
+  {
+    sys_id: ref(INPUT_FIELDS_VAR),
+    element: ref('field_values'),
+    label: ref('Field values'),
+    internal_type: ref('template_value'),
+    mandatory: ref('true'),
+    order: ref('200'),
+    reference: ref(''),
+    attributes: ref(''),
+  },
+  {
+    sys_id: ref(INPUT_RECORD_VAR),
+    element: ref('record'),
+    label: ref('Record'),
+    internal_type: ref('document_id'),
+    mandatory: ref('false'),
+    order: ref('300'),
+    reference: ref(''),
+    // Real ATF document_id inputs (e.g. the "Record" field) declare a mapper.
+    attributes: ref(
+      'element_mapping_provider=com.glide.automated_testing_framework.ATFVariableElementMapper',
+    ),
+  },
+  {
+    sys_id: ref('e0000000000000000000000000000001'),
+    element: ref('assert_type'),
+    label: ref('Assert type'),
+    internal_type: ref('choice'),
+    mandatory: ref('false'),
+    order: ref('400'),
+    reference: ref(''),
+    attributes: ref(''),
+    choice_table: ref(''),
+    default_value: ref('record_successfully_inserted'),
+  },
+];
+
+function buildMockClient(
+  overrides: Partial<Record<string, unknown>> = {},
+): ServiceNowClient {
+  // Captures the last upsert script so the sys_variable_value readback below can
+  // echo what it wrote — that is what verifyInputsWritten polls to confirm.
+  let lastUpsertScript = '';
+
+  const listRecords = vi.fn(async (table: string): Promise<unknown[]> => {
+    switch (table) {
+      case 'sys_atf_step_config':
+        return [
+          { sys_id: ref(STEP_CONFIG_SYS), name: ref('Set Field Values') },
+        ];
+      case 'sys_atf_test':
+        return [
+          {
+            sys_id: ref(TEST_SYS),
+            name: ref('RCP — Submit happy path'),
+            description: ref('Happy path'),
+            active: ref('true'),
+            sys_updated_on: ref('2026-06-10 12:00:00'),
+          },
+        ];
+      case 'atf_input_variable':
+        return INPUT_DEFS;
+      case 'atf_output_variable':
+        return [
+          {
+            element: ref('record_id'),
+            label: ref('Record'),
+            internal_type: ref('document_id'),
+          },
+        ];
+      case 'sys_choice':
+        // ATF stores choice options in sys_choice under the config's pool
+        // column, duplicated per language — verifyChoices dedupes by value.
+        return [
+          {
+            element: ref('assert_type'),
+            value: ref('record_successfully_inserted'),
+            label: ref('Record successfully inserted'),
+          },
+          {
+            element: ref('assert_type'),
+            value: ref('record_successfully_inserted'),
+            label: ref('Se insertó el registro'),
+          },
+          {
+            element: ref('assert_type'),
+            value: ref('record_not_inserted'),
+            label: ref('Record was not inserted'),
+          },
+        ];
+      case 'sys_variable_value': {
+        // Reconstruct the rows the upsert script's setVal() calls would write so
+        // verifyInputsWritten sees the intended values and confirms immediately.
+        const rows: unknown[] = [];
+        const re =
+          /setVal\("[0-9a-f]+",\s*"([0-9a-f]+)",\s*"((?:[^"\\]|\\.)*)"/g;
+        let m: RegExpExecArray | null = re.exec(lastUpsertScript);
+        while (m !== null) {
+          rows.push({
+            variable: ref(m[1]),
+            value: ref(JSON.parse(`"${m[2]}"`)),
+          });
+          m = re.exec(lastUpsertScript);
+        }
+        return rows;
+      }
+      default:
+        return [];
+    }
+  });
+
+  const createRecord = vi.fn(async (table: string): Promise<unknown> => {
+    if (table === 'sys_atf_step') return { sys_id: ref(NEW_STEP_SYS) };
+    if (table === 'sys_variable_value')
+      return { sys_id: ref('99'.padEnd(32, '0')) };
+    return { sys_id: ref(NEW_RECORD_SYS) };
+  });
+
+  return {
+    getInstanceUrl: vi.fn().mockReturnValue('https://dev.example.com'),
+    getRecord: vi.fn().mockResolvedValue({
+      sys_id: ref(TEST_SYS),
+      order: ref('1'),
+      step_config: {
+        value: STEP_CONFIG_SYS,
+        display_value: 'Set Field Values',
+      },
+    }),
+    listRecords,
+    createRecord,
+    patchRecord: vi.fn().mockResolvedValue({}),
+    executeBackgroundScriptTrigger: vi.fn(async (script: string) => {
+      lastUpsertScript = script;
+      return { success: true, trigger_sys_id: 'trig' };
+    }),
+    ...overrides,
+  } as unknown as ServiceNowClient;
+}
+
+describe('atf tools (in-memory MCP)', () => {
+  let mcpClient: Client;
+  let teardown: () => Promise<void>;
+
+  beforeEach(async () => {
+    const pair = await buildTestPair(registerAtfTools, buildMockClient());
+    mcpClient = pair.mcpClient;
+    teardown = pair.teardown;
+  });
+
+  afterEach(async () => {
+    await teardown();
+  });
+
+  describe('create_atf_test', () => {
+    it('creates the test and returns sys_id and URL', async () => {
+      const result = await mcpClient.callTool({
+        name: 'create_atf_test',
+        arguments: { name: 'My Test' },
+      });
+      const text = firstText(result);
+      expect(text).toContain('created successfully');
+      expect(text).toContain(NEW_RECORD_SYS);
+      expect(text).toContain('https://dev.example.com/sys_atf_test.do?sys_id=');
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('serialises active as a string', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerAtfTools, mockClient);
+      try {
+        await pair.mcpClient.callTool({
+          name: 'create_atf_test',
+          arguments: { name: 'My Test', active: false },
+        });
+        expect(mockClient.createRecord).toHaveBeenCalledWith(
+          'sys_atf_test',
+          expect.objectContaining({ name: 'My Test', active: 'false' }),
+        );
+      } finally {
+        await pair.teardown();
+      }
+    });
+  });
+
+  describe('update_atf_test', () => {
+    it('soft-deletes via active=false', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerAtfTools, mockClient);
+      try {
+        await pair.mcpClient.callTool({
+          name: 'update_atf_test',
+          arguments: { sys_id: TEST_SYS, active: false },
+        });
+        expect(mockClient.patchRecord).toHaveBeenCalledWith(
+          'sys_atf_test',
+          TEST_SYS,
+          expect.objectContaining({ active: 'false' }),
+        );
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('returns isError on invalid sys_id', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_atf_test',
+        arguments: { sys_id: 'nope', name: 'x' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('add_atf_test_to_suite', () => {
+    it('creates the link with a defaulted order', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerAtfTools, mockClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'add_atf_test_to_suite',
+          arguments: { test_suite: SUITE_SYS, test: TEST_SYS },
+        });
+        expect(mockClient.createRecord).toHaveBeenCalledWith(
+          'sys_atf_test_suite_test',
+          expect.objectContaining({
+            test_suite: SUITE_SYS,
+            test: TEST_SYS,
+            order: '100',
+          }),
+        );
+        expect(result.isError).toBeFalsy();
+      } finally {
+        await pair.teardown();
+      }
+    });
+  });
+
+  describe('add_atf_step', () => {
+    it('creates the step via the Table API and writes inputs via a server-side script', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerAtfTools, mockClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'add_atf_step',
+          arguments: {
+            test: TEST_SYS,
+            step_config: 'Set Field Values',
+            inputs: [{ element: 'table', value: 'incident' }],
+          },
+        });
+        const text = firstText(result);
+        expect(text).toContain(NEW_STEP_SYS);
+
+        expect(mockClient.createRecord).toHaveBeenCalledWith(
+          'sys_atf_step',
+          expect.objectContaining({
+            test: TEST_SYS,
+            step_config: STEP_CONFIG_SYS,
+            order: '100',
+            table: 'incident',
+          }),
+        );
+        // input values must NOT go through the (ACL-blocked) Table API
+        expect(mockClient.createRecord).not.toHaveBeenCalledWith(
+          'sys_variable_value',
+          expect.anything(),
+        );
+        const script = (
+          mockClient.executeBackgroundScriptTrigger as ReturnType<typeof vi.fn>
+        ).mock.calls[0][0] as string;
+        expect(script).toContain('sys_variable_value');
+        expect(script).toContain(NEW_STEP_SYS);
+        expect(script).toContain(INPUT_TABLE_VAR);
+        expect(script).toContain('incident');
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('wires a document_id (element_mapping_provider) dependency as both a sys_variable_value token and a sys_element_mapping row', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerAtfTools, mockClient);
+      try {
+        await pair.mcpClient.callTool({
+          name: 'add_atf_step',
+          arguments: {
+            test: TEST_SYS,
+            step_config: 'Set Field Values',
+            inputs: [
+              {
+                element: 'record',
+                map_from_step: PRODUCER_STEP_SYS,
+                map_output: 'record_id',
+              },
+            ],
+          },
+        });
+        const script = (
+          mockClient.executeBackgroundScriptTrigger as ReturnType<typeof vi.fn>
+        ).mock.calls[0][0] as string;
+        expect(script).toContain(INPUT_RECORD_VAR);
+        // Stored as the sys_id token (what the UI's dot-walking picker writes);
+        // the data-pill text is display-only and never stored.
+        expect(script).toContain(`{{step['${PRODUCER_STEP_SYS}'].record_id}}`);
+        expect(script).not.toContain('{{Step 1:');
+        // …and the companion sys_element_mapping row that makes the token
+        // resolve at runtime (table = the config's pool column, field = element).
+        expect(script).toContain('sys_element_mapping');
+        expect(script).toContain(
+          `var__m_atf_input_variable_${STEP_CONFIG_SYS}`,
+        );
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('encodes a step dependency into an encoded-query field as the sys_id token', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerAtfTools, mockClient);
+      try {
+        await pair.mcpClient.callTool({
+          name: 'add_atf_step',
+          arguments: {
+            test: TEST_SYS,
+            step_config: 'Set Field Values',
+            inputs: [
+              {
+                element: 'field_values',
+                map_from_step: PRODUCER_STEP_SYS,
+                map_output: 'record_id',
+              },
+            ],
+          },
+        });
+        const script = (
+          mockClient.executeBackgroundScriptTrigger as ReturnType<typeof vi.fn>
+        ).mock.calls[0][0] as string;
+        expect(script).toContain(INPUT_FIELDS_VAR);
+        expect(script).toContain(`{{step['${PRODUCER_STEP_SYS}'].record_id}}`);
+        // Encoded-query fields embed the token in the value string and have no
+        // element_mapping_provider — no sys_element_mapping row is written.
+        expect(script).not.toContain('sys_element_mapping');
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('rejects mapping a non-existent output on the producer step', async () => {
+      const result = await mcpClient.callTool({
+        name: 'add_atf_step',
+        arguments: {
+          test: TEST_SYS,
+          step_config: 'Set Field Values',
+          inputs: [
+            {
+              element: 'record',
+              map_from_step: PRODUCER_STEP_SYS,
+              map_output: 'not_an_output',
+            },
+          ],
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect(firstText(result)).toContain('is not an output of step');
+    });
+
+    it('rejects a choice value outside the resolved option list', async () => {
+      const result = await mcpClient.callTool({
+        name: 'add_atf_step',
+        arguments: {
+          test: TEST_SYS,
+          step_config: 'Set Field Values',
+          inputs: [{ element: 'assert_type', value: 'bogus_assert' }],
+        },
+      });
+      expect(result.isError).toBe(true);
+      const text = firstText(result);
+      expect(text).toContain('is a choice');
+      expect(text).toContain('record_successfully_inserted');
+    });
+
+    it('accepts a valid choice value', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerAtfTools, mockClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'add_atf_step',
+          arguments: {
+            test: TEST_SYS,
+            step_config: 'Set Field Values',
+            inputs: [{ element: 'assert_type', value: 'record_not_inserted' }],
+          },
+        });
+        expect(result.isError).toBeFalsy();
+        expect(firstText(result)).toContain('confirmed');
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('auto-fills omitted inputs from the step config dictionary defaults', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerAtfTools, mockClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'add_atf_step',
+          arguments: {
+            test: TEST_SYS,
+            step_config: 'Set Field Values',
+            inputs: [{ element: 'table', value: 'incident' }],
+          },
+        });
+        const script = (
+          mockClient.executeBackgroundScriptTrigger as ReturnType<typeof vi.fn>
+        ).mock.calls[0][0] as string;
+        // assert_type was omitted but declares default_value — written like the UI would.
+        expect(script).toContain('record_successfully_inserted');
+        const text = firstText(result);
+        expect(text).toContain('Defaults:');
+        expect(text).toContain('assert_type=record_successfully_inserted');
+        // The assert input ended up set, so no vacuous-assert warning.
+        expect(text).not.toContain('asserts nothing');
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it("lists the new step's output elements for downstream mapping", async () => {
+      const result = await mcpClient.callTool({
+        name: 'add_atf_step',
+        arguments: {
+          test: TEST_SYS,
+          step_config: 'Set Field Values',
+          inputs: [{ element: 'table', value: 'incident' }],
+        },
+      });
+      const text = firstText(result);
+      expect(text).toContain('Outputs:');
+      expect(text).toContain('record_id [document_id]');
+      expect(text).toContain(`map_from_step=${NEW_STEP_SYS}`);
+    });
+
+    it('rejects an unknown input element', async () => {
+      const result = await mcpClient.callTool({
+        name: 'add_atf_step',
+        arguments: {
+          test: TEST_SYS,
+          step_config: 'Set Field Values',
+          inputs: [{ element: 'nonexistent', value: 'x' }],
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect(firstText(result)).toContain('Unknown input element');
+    });
+
+    it('rejects providing both value and a mapping', async () => {
+      const result = await mcpClient.callTool({
+        name: 'add_atf_step',
+        arguments: {
+          test: TEST_SYS,
+          step_config: 'Set Field Values',
+          inputs: [
+            {
+              element: 'record',
+              value: 'abc',
+              map_from_step: PRODUCER_STEP_SYS,
+              map_output: 'record_id',
+            },
+          ],
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect(firstText(result)).toContain('not both');
+    });
+
+    it('rejects a non-sys_id literal for a document_id input', async () => {
+      const result = await mcpClient.callTool({
+        name: 'add_atf_step',
+        arguments: {
+          test: TEST_SYS,
+          step_config: 'Set Field Values',
+          inputs: [{ element: 'record', value: 'not-a-sys-id' }],
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect(firstText(result)).toContain('expects a 32-char sys_id');
+    });
+
+    it('returns isError on invalid test sys_id', async () => {
+      const result = await mcpClient.callTool({
+        name: 'add_atf_step',
+        arguments: { test: 'bad', step_config: 'Set Field Values' },
+      });
+      expect(result.isError).toBe(true);
+    });
+
+    it('surfaces SnApiError with status in message', async () => {
+      const mockClient = buildMockClient({
+        createRecord: vi
+          .fn()
+          .mockRejectedValue(
+            new SnApiError(403, 'Forbidden', 'ACL', 'https://example.com'),
+          ),
+      });
+      const pair = await buildTestPair(registerAtfTools, mockClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'add_atf_step',
+          arguments: { test: TEST_SYS, step_config: 'Set Field Values' },
+        });
+        expect(result.isError).toBe(true);
+        expect(firstText(result)).toContain('403');
+      } finally {
+        await pair.teardown();
+      }
+    });
+  });
+
+  describe('update_atf_step', () => {
+    it('warns when an assert-type input is left empty', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_atf_step',
+        arguments: {
+          sys_id: NEW_STEP_SYS,
+          inputs: [{ element: 'assert_type', value: '' }],
+        },
+      });
+      expect(result.isError).toBeFalsy();
+      const text = firstText(result);
+      expect(text).toContain('⚠ Assert input "assert_type" is empty');
+      expect(text).toContain('record_successfully_inserted');
+    });
+  });
+
+  describe('list_atf_tests', () => {
+    it('searches by name and filters by active by default', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerAtfTools, mockClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'list_atf_tests',
+          arguments: { name_contains: 'RCP' },
+        });
+        const query = (mockClient.listRecords as ReturnType<typeof vi.fn>).mock
+          .calls[0][1] as string;
+        expect(query).toContain('active=true');
+        expect(query).toContain('nameLIKERCP');
+        expect(query).toContain('ORDERBYDESCsys_updated_on');
+        const text = firstText(result);
+        expect(text).toContain('RCP — Submit happy path');
+        expect(text).toContain(TEST_SYS);
+        expect(result.isError).toBeFalsy();
+      } finally {
+        await pair.teardown();
+      }
+    });
+  });
+
+  describe('get_atf_step_config_schema', () => {
+    it('returns inputs and outputs for a config resolved by name', async () => {
+      const result = await mcpClient.callTool({
+        name: 'get_atf_step_config_schema',
+        arguments: { step_config: 'Set Field Values' },
+      });
+      const text = firstText(result);
+      expect(text).toContain('table');
+      expect(text).toContain('field_values');
+      expect(text).toContain('record_id');
+      // Choice inputs surface their valid values so they are seen before writing.
+      expect(text).toContain('choices: record_successfully_inserted');
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  describe('list_atf_step_configs', () => {
+    it('lists configs and filters by active by default', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerAtfTools, mockClient);
+      try {
+        await pair.mcpClient.callTool({
+          name: 'list_atf_step_configs',
+          arguments: { name_contains: 'Set' },
+        });
+        const query = (mockClient.listRecords as ReturnType<typeof vi.fn>).mock
+          .calls[0][1] as string;
+        expect(query).toContain('active=true');
+        expect(query).toContain('deprecated=false');
+        expect(query).toContain('nameLIKESet');
+      } finally {
+        await pair.teardown();
+      }
+    });
+  });
+});

--- a/src/tools/atf.ts
+++ b/src/tools/atf.ts
@@ -802,6 +802,9 @@ export function registerAtfTools(
     },
     async ({ sys_id }) => {
       try {
+        if (!isSysId(sys_id))
+          return errText(`"${sys_id}" is not a valid test sys_id.`);
+
         const test = await client.getRecord<SnRecord>(TEST_TABLE, sys_id);
         const steps = await client.listRecords<SnRecord>(
           STEP_TABLE,
@@ -1338,6 +1341,17 @@ export function registerAtfTools(
         ]);
         const configSysId = val(step, 'step_config');
 
+        let defs: AtfInputDef[] = [];
+        let resolved: ResolvedInput[] = [];
+        if (inputs?.length) {
+          const [fetchedDefs, producers] = await Promise.all([
+            fetchInputDefs(client, configSysId),
+            fetchProducers(client, inputs),
+          ]);
+          defs = fetchedDefs;
+          resolved = resolveStepInputs(defs, inputs, producers);
+        }
+
         const body: Record<string, unknown> = {};
         if (order !== undefined) body.order = String(order);
         if (active !== undefined) body.active = String(active);
@@ -1351,12 +1365,7 @@ export function registerAtfTools(
 
         let inputStatus = 'Inputs:         none';
         let assertWarnings: string[] = [];
-        if (inputs?.length) {
-          const [defs, producers] = await Promise.all([
-            fetchInputDefs(client, configSysId),
-            fetchProducers(client, inputs),
-          ]);
-          const resolved = resolveStepInputs(defs, inputs, producers);
+        if (resolved.length) {
           // sys_variable_value rejects REST writes (ACL); write server-side via a
           // +1s trigger, then read back to confirm what actually landed.
           await client.executeBackgroundScriptTrigger(

--- a/src/tools/atf.ts
+++ b/src/tools/atf.ts
@@ -1,0 +1,1400 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ServiceNowClient } from '../clients/servicenow.js';
+import type { SnReference } from '../types/servicenow.js';
+import {
+  handleError,
+  isSysId,
+  resolveDisplay,
+  resolveValue,
+} from './helpers.js';
+import {
+  AtfAddStep,
+  AtfAddTestToSuite,
+  AtfGetStepConfigSchema,
+  AtfGetTest,
+  AtfListStepConfigs,
+  AtfListTests,
+  AtfTestCreate,
+  AtfTestSuiteCreate,
+  AtfTestSuiteUpdate,
+  AtfTestUpdate,
+  AtfUpdateStep,
+} from './schemas.js';
+
+const STEP_CONFIG_TABLE = 'sys_atf_step_config';
+const TEST_TABLE = 'sys_atf_test';
+const SUITE_TABLE = 'sys_atf_test_suite';
+const SUITE_TEST_TABLE = 'sys_atf_test_suite_test';
+const STEP_TABLE = 'sys_atf_step';
+const INPUT_VAR_TABLE = 'atf_input_variable';
+const OUTPUT_VAR_TABLE = 'atf_output_variable';
+const VAR_VALUE_TABLE = 'sys_variable_value';
+const CHOICE_TABLE = 'sys_choice';
+
+/**
+ * A step-to-step dependency is stored as the sys_id token form
+ * `{{step['<producer sys_id>'].<output element>}}` in sys_variable_value, for
+ * every consuming field type. (The human-readable data-pill text
+ * `{{Step <n>: <config>.<label>}}` is display-only and must NOT be stored.)
+ *
+ * That token alone is enough for tokens embedded inside encoded queries
+ * (Conditions / Field values). But for a WHOLE-VALUE map into an
+ * element_mapping_provider field — e.g. the "Record" (document_id) field of
+ * "Open an Existing Record" — the token in sys_variable_value is never resolved
+ * at runtime on its own (the step fails with "Table ... does not have a record
+ * with id '{{step[...]}}'"). Those fields also need a companion row in
+ * sys_element_mapping (table = the `var__m_atf_input_variable_<configSysId>`
+ * pool column, field = element, id = step sys_id, value = the token). The UI's
+ * data-pill picker writes both; so does buildInputUpsertScript.
+ */
+
+type SnRecord = Record<string, SnReference | undefined>;
+
+const val = (r: SnRecord, f: string): string =>
+  r[f] ? resolveValue(r[f] as SnReference) : '';
+const disp = (r: SnRecord, f: string): string =>
+  r[f] ? resolveDisplay(r[f] as SnReference) : '';
+
+interface AtfInputDef {
+  sysId: string;
+  element: string;
+  label: string;
+  internalType: string;
+  mandatory: boolean;
+  order: number;
+  reference: string;
+  /**
+   * True when the input's dictionary `attributes` declare an
+   * `element_mapping_provider` (e.g. the "Record" field of "Open an Existing
+   * Record"). Such fields resolve a step-output mapping ONLY via a companion
+   * sys_element_mapping row — a raw sys_variable_value token is never resolved
+   * at runtime. See buildInputUpsertScript.
+   */
+  hasElementMapping: boolean;
+  /** True for internal_type === 'choice'. */
+  isChoice: boolean;
+  /**
+   * The valid choice values, resolved from sys_choice (the per-config pool
+   * column var__m_atf_input_variable_<configSysId>). Empty when the input is
+   * not a choice, or when its options are generated dynamically (see
+   * dynamicChoices) and so can't be enumerated from a table.
+   */
+  choices: { value: string; label: string }[];
+  /**
+   * True when the choice list is produced at runtime by a script
+   * (attributes `choice_script=...`) or sourced from a reference table
+   * (choice_table) — its options can't be enumerated up front, so a literal
+   * value for it is NOT validated. defaultValue carries the configured fallback.
+   */
+  dynamicChoices: boolean;
+  defaultValue: string;
+}
+
+interface AtfOutputDef {
+  element: string;
+  label: string;
+  internalType: string;
+}
+
+function recordUrl(
+  client: ServiceNowClient,
+  table: string,
+  sysId: string,
+): string {
+  return `${client.getInstanceUrl()}/${table}.do?sys_id=${sysId}`;
+}
+
+async function resolveStepConfig(
+  client: ServiceNowClient,
+  idOrName: string,
+): Promise<{ sysId: string; name: string }> {
+  if (isSysId(idOrName)) {
+    const rec = await client.getRecord<SnRecord>(STEP_CONFIG_TABLE, idOrName, [
+      'sys_id',
+      'name',
+    ]);
+    return { sysId: val(rec, 'sys_id'), name: disp(rec, 'name') };
+  }
+  const matches = await client.listRecords<SnRecord>(
+    STEP_CONFIG_TABLE,
+    `name=${idOrName}`,
+    ['sys_id', 'name'],
+    5,
+  );
+  if (matches.length === 0) {
+    throw new Error(
+      `No step config found named "${idOrName}". Call list_atf_step_configs to discover valid names.`,
+    );
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Multiple step configs named "${idOrName}". Pass the sys_id instead.`,
+    );
+  }
+  return { sysId: val(matches[0], 'sys_id'), name: disp(matches[0], 'name') };
+}
+
+/**
+ * The enumerable choice options for a step config's `choice` inputs, keyed by
+ * element. ATF stores them in sys_choice under the config's pool column
+ * `var__m_atf_input_variable_<configSysId>` (the same column buildInputUpsertScript
+ * uses for sys_element_mapping), and duplicates each row per language — we dedupe
+ * by value, keeping the first (English-first via the language sort). Inputs whose
+ * options are script- or table-generated have no rows here; see
+ * AtfInputDef.dynamicChoices.
+ */
+async function fetchChoices(
+  client: ServiceNowClient,
+  stepConfigSysId: string,
+): Promise<Map<string, { value: string; label: string }[]>> {
+  const recs = await client.listRecords<SnRecord>(
+    CHOICE_TABLE,
+    `name=var__m_atf_input_variable_${stepConfigSysId}^inactive=false^ORDERBYelement^ORDERBYsequence^ORDERBYlanguage`,
+    ['element', 'value', 'label'],
+    500,
+  );
+  const byElement = new Map<string, { value: string; label: string }[]>();
+  for (const r of recs) {
+    const element = val(r, 'element');
+    const value = val(r, 'value');
+    const list = byElement.get(element) ?? [];
+    if (!list.some((c) => c.value === value)) {
+      list.push({ value, label: disp(r, 'label') || value });
+    }
+    byElement.set(element, list);
+  }
+  return byElement;
+}
+
+async function fetchInputDefs(
+  client: ServiceNowClient,
+  stepConfigSysId: string,
+): Promise<AtfInputDef[]> {
+  const [recs, choices] = await Promise.all([
+    client.listRecords<SnRecord>(
+      INPUT_VAR_TABLE,
+      `model=${stepConfigSysId}^active=true^ORDERBYorder`,
+      [
+        'sys_id',
+        'element',
+        'label',
+        'internal_type',
+        'mandatory',
+        'order',
+        'reference',
+        'attributes',
+        'choice_table',
+        'default_value',
+      ],
+      100,
+    ),
+    fetchChoices(client, stepConfigSysId),
+  ]);
+  return recs.map((r) => {
+    const internalType = val(r, 'internal_type');
+    const attributes = val(r, 'attributes');
+    return {
+      sysId: val(r, 'sys_id'),
+      element: val(r, 'element'),
+      label: disp(r, 'label') || val(r, 'element'),
+      internalType,
+      mandatory: val(r, 'mandatory') === 'true',
+      order: parseInt(val(r, 'order') || '100', 10) || 100,
+      reference: disp(r, 'reference'),
+      hasElementMapping: attributes.includes('element_mapping_provider'),
+      isChoice: internalType === 'choice',
+      choices: choices.get(val(r, 'element')) ?? [],
+      dynamicChoices:
+        attributes.includes('choice_script') || val(r, 'choice_table') !== '',
+      defaultValue: val(r, 'default_value'),
+    };
+  });
+}
+
+async function fetchOutputDefs(
+  client: ServiceNowClient,
+  stepConfigSysId: string,
+): Promise<AtfOutputDef[]> {
+  const recs = await client.listRecords<SnRecord>(
+    OUTPUT_VAR_TABLE,
+    `model=${stepConfigSysId}^active=true^ORDERBYorder`,
+    ['element', 'label', 'internal_type'],
+    100,
+  );
+  return recs.map((r) => ({
+    element: val(r, 'element'),
+    label: disp(r, 'label') || val(r, 'element'),
+    internalType: val(r, 'internal_type'),
+  }));
+}
+
+/**
+ * The valid output elements of an earlier step, used to validate a later step's
+ * `map_output` before wiring the dependency token. configName is only for the
+ * error message.
+ */
+interface ProducerInfo {
+  configName: string;
+  outputElements: Set<string>;
+}
+
+async function fetchProducerInfo(
+  client: ServiceNowClient,
+  stepSysId: string,
+): Promise<ProducerInfo> {
+  const step = await client.getRecord<SnRecord>(STEP_TABLE, stepSysId, [
+    'step_config',
+  ]);
+  const outputs = await fetchOutputDefs(client, val(step, 'step_config'));
+  return {
+    configName: disp(step, 'step_config'),
+    outputElements: new Set(outputs.map((o) => o.element)),
+  };
+}
+
+/** Pre-loads producer metadata for every distinct mapped step in `inputs`. */
+async function fetchProducers(
+  client: ServiceNowClient,
+  inputs: InputSpec[] | undefined,
+): Promise<Map<string, ProducerInfo>> {
+  const ids = [
+    ...new Set(
+      (inputs ?? [])
+        .map((i) => i.map_from_step)
+        .filter((id): id is string => !!id && isSysId(id)),
+    ),
+  ];
+  const entries = await Promise.all(
+    ids.map(async (id) => [id, await fetchProducerInfo(client, id)] as const),
+  );
+  return new Map(entries);
+}
+
+async function nextOrder(
+  client: ServiceNowClient,
+  table: string,
+  query: string,
+): Promise<number> {
+  const recs = await client.listRecords<SnRecord>(
+    table,
+    `${query}^ORDERBYDESCorder`,
+    ['order'],
+    1,
+  );
+  if (recs.length === 0) return 100;
+  const max = parseInt(val(recs[0], 'order') || '0', 10);
+  return (Number.isNaN(max) ? 0 : max) + 100;
+}
+
+type InputSpec = {
+  element: string;
+  value?: string;
+  map_from_step?: string;
+  map_output?: string;
+};
+
+interface ResolvedInput {
+  element: string;
+  variableSysId: string;
+  value: string;
+  order: number;
+  /**
+   * True when this is a whole-value step-output mapping into an
+   * element_mapping_provider field — requires a companion sys_element_mapping
+   * row so the token resolves at runtime.
+   */
+  needsElementMapping: boolean;
+}
+
+/**
+ * Validates each input against the step config's definitions and resolves its
+ * stored value (literal, or a step-output dependency token). Pure — no I/O — so
+ * callers can surface validation errors synchronously; producer metadata for a
+ * mapping must be pre-loaded into `producers` (keyed by step sys_id) via
+ * fetchProducers, which is also used to validate the mapped output element.
+ *
+ * A step dependency is always stored as the sys_id token form
+ * `{{step['<producer sys_id>'].<output element>}}` — see the note above
+ * fetchProducerInfo.
+ */
+function resolveStepInputs(
+  defs: AtfInputDef[],
+  inputs: InputSpec[],
+  producers: Map<string, ProducerInfo>,
+): ResolvedInput[] {
+  const byElement = new Map(defs.map((d) => [d.element, d]));
+  const validElements = defs.map((d) => d.element).join(', ') || '(none)';
+
+  return inputs.map((input) => {
+    const def = byElement.get(input.element);
+    if (!def) {
+      throw new Error(
+        `Unknown input element "${input.element}" for this step config. Valid elements: ${validElements}.`,
+      );
+    }
+
+    const isMap =
+      input.map_from_step !== undefined || input.map_output !== undefined;
+    let value: string;
+    if (isMap) {
+      if (input.value !== undefined) {
+        throw new Error(
+          `Input "${input.element}": provide either value or map_from_step+map_output, not both.`,
+        );
+      }
+      if (!input.map_from_step || !input.map_output) {
+        throw new Error(
+          `Input "${input.element}": map_from_step and map_output must both be set.`,
+        );
+      }
+      if (!isSysId(input.map_from_step)) {
+        throw new Error(
+          `Input "${input.element}": map_from_step must be the 32-char sys_id of an earlier step.`,
+        );
+      }
+      const producer = producers.get(input.map_from_step);
+      if (!producer) {
+        throw new Error(
+          `Input "${input.element}": could not load producer step ${input.map_from_step}.`,
+        );
+      }
+      if (!producer.outputElements.has(input.map_output)) {
+        const valid = [...producer.outputElements].join(', ') || '(none)';
+        throw new Error(
+          `Input "${input.element}": "${input.map_output}" is not an output of step ${input.map_from_step} (${producer.configName}). Valid outputs: ${valid}.`,
+        );
+      }
+      // The sys_id token form is what the UI's dot-walking picker stores in
+      // sys_variable_value. For element_mapping_provider fields it is also
+      // mirrored into a sys_element_mapping row (see buildInputUpsertScript),
+      // which is what actually makes it resolve at runtime.
+      value = `{{step['${input.map_from_step}'].${input.map_output}}}`;
+    } else {
+      if (input.value === undefined) {
+        throw new Error(
+          `Input "${input.element}": provide a value, or map_from_step + map_output.`,
+        );
+      }
+      value = input.value;
+      if (
+        (def.internalType === 'reference' ||
+          def.internalType === 'document_id') &&
+        value !== '' &&
+        !value.includes('{{') &&
+        !isSysId(value)
+      ) {
+        throw new Error(
+          `Input "${input.element}" is a ${def.internalType} and expects a 32-char sys_id (or a {{step[...]}} mapping token), got "${value}".`,
+        );
+      }
+      if (
+        def.isChoice &&
+        def.choices.length > 0 &&
+        value !== '' &&
+        !value.includes('{{') &&
+        !def.choices.some((c) => c.value === value)
+      ) {
+        const valid = def.choices.map((c) => c.value).join(', ');
+        throw new Error(
+          `Input "${input.element}" is a choice and "${value}" is not one of its values. Valid: ${valid}.`,
+        );
+      }
+    }
+
+    return {
+      element: input.element,
+      variableSysId: def.sysId,
+      value,
+      order: def.order,
+      needsElementMapping: isMap && def.hasElementMapping,
+    };
+  });
+}
+
+/**
+ * Builds a global background script that upserts each input value into
+ * sys_variable_value. Step input values CANNOT be written over the Table API —
+ * that table's ACLs reject REST insert/update with HTTP 403 — so they must be
+ * written server-side, where GlideRecord bypasses those ACLs. Inserting the
+ * step already auto-creates the (empty) value rows, so we find-or-update by
+ * (document_key, variable) to avoid duplicates.
+ */
+function buildInputUpsertScript(
+  stepSysId: string,
+  resolved: ResolvedInput[],
+  stepConfigSysId: string,
+): string {
+  const lines = resolved.map(
+    (r) =>
+      `  setVal(${JSON.stringify(stepSysId)}, ${JSON.stringify(r.variableSysId)}, ${JSON.stringify(r.value)}, ${JSON.stringify(String(r.order))});`,
+  );
+  // The pool column that backs this step config's inputs — the `table` of a
+  // sys_element_mapping row. Equals the atf_input_variable `name` shared by all
+  // inputs of the config.
+  const mappingTable = `var__m_atf_input_variable_${stepConfigSysId}`;
+  // Whole-value step-output maps into element_mapping_provider fields (e.g. the
+  // "Record" document_id of "Open an Existing Record") resolve at runtime ONLY
+  // via a sys_element_mapping row — the sys_variable_value token alone is passed
+  // through literally and the step fails with "Table ... does not have a record
+  // with id '{{step[...]}}'". This is what the UI's data-pill picker writes.
+  const mappingLines = resolved
+    .filter((r) => r.needsElementMapping)
+    .map(
+      (r) =>
+        `  setMapping(${JSON.stringify(stepSysId)}, ${JSON.stringify(r.element)}, ${JSON.stringify(r.value)});`,
+    );
+  // The sys_element_mapping helper + table const are only emitted when at least
+  // one input actually needs a mapping row, keeping the script minimal.
+  const mappingHelper = mappingLines.length
+    ? [
+        `  var MAPPING_TABLE = ${JSON.stringify(mappingTable)};`,
+        '  function setMapping(stepId, field, value) {',
+        "    var gr = new GlideRecord('sys_element_mapping');",
+        "    gr.addQuery('table', MAPPING_TABLE);",
+        "    gr.addQuery('field', field);",
+        "    gr.addQuery('id', stepId);",
+        '    gr.query();',
+        '    if (gr.next()) {',
+        "      gr.setValue('value', value);",
+        '      gr.update();',
+        '    } else {',
+        '      gr.initialize();',
+        "      gr.setValue('table', MAPPING_TABLE);",
+        "      gr.setValue('field', field);",
+        "      gr.setValue('id', stepId);",
+        "      gr.setValue('value', value);",
+        '      gr.insert();',
+        '    }',
+        '  }',
+      ]
+    : [];
+  return [
+    '(function () {',
+    '  function setVal(stepId, varId, value, order) {',
+    "    var gr = new GlideRecord('sys_variable_value');",
+    "    gr.addQuery('document', 'sys_atf_step');",
+    "    gr.addQuery('document_key', stepId);",
+    "    gr.addQuery('variable', varId);",
+    '    gr.query();',
+    '    if (gr.next()) {',
+    "      gr.setValue('value', value);",
+    '      gr.update();',
+    '    } else {',
+    '      gr.initialize();',
+    "      gr.setValue('document', 'sys_atf_step');",
+    "      gr.setValue('document_key', stepId);",
+    "      gr.setValue('variable', varId);",
+    "      gr.setValue('value', value);",
+    "      gr.setValue('order', order);",
+    '      gr.insert();',
+    '    }',
+    '  }',
+    ...mappingHelper,
+    ...lines,
+    ...mappingLines,
+    // Re-save the step so its before-BRs ("Generate Description", display-name,
+    // dependent-field processing) re-run now that the inputs exist. The step
+    // was inserted with no inputs, so those BRs first ran against an empty step
+    // (yielding e.g. "Open a new 'undefined' form"). A plain update() here is a
+    // no-op — no field is dirty, so the BRs never re-fire. Blanking description
+    // forces the record dirty; "Generate Description" then recomputes it from
+    // the now-written variable values, matching a manual UI save.
+    `  var stepGr = new GlideRecord('sys_atf_step');`,
+    `  if (stepGr.get(${JSON.stringify(stepSysId)})) {`,
+    `    var priorDescription = stepGr.getValue('description');`,
+    `    stepGr.setValue('description', '');`,
+    `    stepGr.update();`,
+    `    // If no "Generate Description" before-BR repopulated it (e.g. the BR is`,
+    `    // inactive on this instance), restore the prior text rather than leaving`,
+    `    // the step permanently blank.`,
+    `    var checkGr = new GlideRecord('sys_atf_step');`,
+    `    if (checkGr.get(${JSON.stringify(stepSysId)}) && !checkGr.getValue('description') && priorDescription) {`,
+    `      checkGr.setValue('description', priorDescription);`,
+    `      checkGr.update();`,
+    `    }`,
+    `  }`,
+    '})();',
+  ].join('\n');
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * The input upsert runs in a +1s sys_trigger (sys_variable_value rejects REST
+ * writes — see buildInputUpsertScript), so executeBackgroundScriptTrigger is
+ * fire-and-forget: it returns before the values exist. Read the rows back so the
+ * tool reports what actually landed instead of optimistically claiming success.
+ * Reads ARE allowed on sys_variable_value — only writes hit the 403 ACL.
+ *
+ * The step insert auto-creates the value rows empty, so a row merely existing is
+ * not proof — we compare the stored value. We check once immediately (the writes
+ * may already be visible) and only sleep-and-retry on a miss, capping the total
+ * wait at a few seconds. Returns the elements still not matching their intended
+ * value (empty array = everything confirmed) plus every stored value keyed by
+ * variable sys_id, so callers can inspect the step's final state (e.g. flag
+ * assert inputs that remain empty) without re-querying.
+ */
+async function verifyInputsWritten(
+  client: ServiceNowClient,
+  stepSysId: string,
+  resolved: ResolvedInput[],
+): Promise<{ pending: string[]; stored: Map<string, string> }> {
+  const retryDelaysMs = [700, 900, 1100, 1300];
+  let pending = resolved;
+  let stored = new Map<string, string>();
+  for (let attempt = 0; ; attempt++) {
+    const rows = await client.listRecords<SnRecord>(
+      VAR_VALUE_TABLE,
+      `document=${STEP_TABLE}^document_key=${stepSysId}`,
+      ['variable', 'value'],
+      200,
+    );
+    stored = new Map(rows.map((r) => [val(r, 'variable'), val(r, 'value')]));
+    pending = pending.filter((r) => stored.get(r.variableSysId) !== r.value);
+    if (pending.length === 0 || attempt >= retryDelaysMs.length) break;
+    await sleep(retryDelaysMs[attempt]);
+  }
+  return { pending: pending.map((r) => r.element), stored };
+}
+
+/**
+ * ATF assert-type choice inputs (assert_type on "Submit a Form (SP)", "Record
+ * Insert", …) are optional in the dictionary, yet a step whose assert is empty
+ * asserts NOTHING and can pass vacuously — the #1 source of false-green ATF
+ * tests. Flags every assert-like choice input whose stored value is empty.
+ */
+function buildAssertWarnings(
+  defs: AtfInputDef[],
+  stored: Map<string, string>,
+): string[] {
+  return defs
+    .filter((d) => d.isChoice && d.element.includes('assert'))
+    .filter((d) => !stored.get(d.sysId))
+    .map((d) => {
+      const choices = d.choices.length
+        ? ` Valid values: ${d.choices.map((c) => c.value).join(', ')}.`
+        : '';
+      return `⚠ Assert input "${d.element}" is empty — the step asserts nothing and can pass even when the behavior under test fails. Set it explicitly.${choices}`;
+    });
+}
+
+/** Renders the verifyInputsWritten outcome as a status line for both write tools. */
+function formatInputStatus(
+  pending: string[],
+  resolved: ResolvedInput[],
+): string {
+  const applied = resolved
+    .map((r) => r.element)
+    .filter((e) => !pending.includes(e));
+  if (pending.length === 0) {
+    return `Inputs:      ${applied.join(', ')} — applied and confirmed.`;
+  }
+  return [
+    `Inputs:      ${applied.length ? `${applied.join(', ')} confirmed; ` : ''}NOT confirmed: ${pending.join(', ')}.`,
+    '             The server-side write may still be settling or was rejected —',
+    '             re-read with get_atf_test, or retry update_atf_step.',
+  ].join('\n');
+}
+
+export function registerAtfTools(
+  server: McpServer,
+  client: ServiceNowClient,
+): void {
+  // ── Read: list step configs ──────────────────────────────────────────────
+  server.registerTool(
+    'list_atf_step_configs',
+    {
+      title: 'List ATF Step Configs',
+      description: [
+        'Lists ServiceNow ATF step config types (sys_atf_step_config) — the building',
+        'blocks available when adding steps to a test (e.g. "Record Insert",',
+        '"Open a New Form", "Run Server Side Script").',
+        '',
+        'Filter by category (Server, Form, REST, Service Catalog, …) or by a name',
+        'substring. Returns name, sys_id, category and batch-order constraint.',
+        '',
+        "Call get_atf_step_config_schema next to see a config's inputs and outputs.",
+      ].join('\n'),
+      inputSchema: AtfListStepConfigs.shape,
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async ({ name_contains, category, active_only, limit }) => {
+      try {
+        const clauses: string[] = [];
+        if (active_only) clauses.push('active=true', 'deprecated=false');
+        if (name_contains) clauses.push(`nameLIKE${name_contains}`);
+        if (category) clauses.push(`category.name=${category}`);
+        clauses.push('ORDERBYname');
+        const recs = await client.listRecords<SnRecord>(
+          STEP_CONFIG_TABLE,
+          clauses.join('^'),
+          ['sys_id', 'name', 'category', 'step_env', 'batch_order_constraint'],
+          limit,
+        );
+
+        const rows = recs.map((r) => ({
+          name: disp(r, 'name'),
+          sys_id: val(r, 'sys_id'),
+          category: disp(r, 'category'),
+          environment: disp(r, 'step_env'),
+          batch_order_constraint: disp(r, 'batch_order_constraint'),
+        }));
+
+        const summary = [
+          `${rows.length} step config(s)${category ? ` in category "${category}"` : ''}${name_contains ? ` matching "${name_contains}"` : ''}:`,
+          '',
+          ...rows.map(
+            (r) =>
+              `• ${r.name}${r.category ? ` [${r.category}]` : ''} — ${r.sys_id}`,
+          ),
+        ].join('\n');
+
+        return {
+          content: [
+            { type: 'text' as const, text: summary },
+            { type: 'text' as const, text: JSON.stringify(rows, null, 2) },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  // ── Read: step config schema (inputs + outputs) ───────────────────────────
+  server.registerTool(
+    'get_atf_step_config_schema',
+    {
+      title: 'Get ATF Step Config Schema',
+      description: [
+        'Returns the input and output variables of an ATF step config.',
+        '',
+        'INPUTS are the elements you set when adding a step (add_atf_step). Each lists',
+        'its element key, label, internal_type (table_name, reference, document_id,',
+        'template_value/condition, choice, string, …) and whether it is mandatory.',
+        '',
+        'OUTPUTS are the values this step produces. Use an output element as map_output',
+        'in a later step to wire a dependency (e.g. "record_id" from a Record Insert).',
+        '',
+        'Pass the step config sys_id OR its exact name.',
+      ].join('\n'),
+      inputSchema: AtfGetStepConfigSchema.shape,
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async ({ step_config }) => {
+      try {
+        const { sysId, name } = await resolveStepConfig(client, step_config);
+        const [inputs, outputs] = await Promise.all([
+          fetchInputDefs(client, sysId),
+          fetchOutputDefs(client, sysId),
+        ]);
+
+        const summary = [
+          `Step config: ${name} (${sysId})`,
+          '',
+          `Inputs (${inputs.length}):`,
+          ...inputs.map((i) => {
+            let choices = '';
+            if (i.isChoice && i.choices.length > 0) {
+              choices = ` — choices: ${i.choices.map((c) => c.value).join(', ')}`;
+            } else if (i.isChoice && i.dynamicChoices) {
+              const def =
+                i.defaultValue && !i.defaultValue.startsWith('javascript:')
+                  ? ` (default: ${i.defaultValue})`
+                  : '';
+              choices = ` — choices: dynamic, verify in UI${def}`;
+            }
+            return `  • ${i.element} — ${i.label} [${i.internalType}]${i.mandatory ? ' (mandatory)' : ''}${i.reference ? ` → ${i.reference}` : ''}${choices}`;
+          }),
+          '',
+          `Outputs (${outputs.length}) — usable as map_output in later steps:`,
+          ...outputs.map(
+            (o) => `  • ${o.element} — ${o.label} [${o.internalType}]`,
+          ),
+        ].join('\n');
+
+        return {
+          content: [
+            { type: 'text' as const, text: summary },
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                { sys_id: sysId, name, inputs, outputs },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  // ── Read: list/search tests ───────────────────────────────────────────────
+  server.registerTool(
+    'list_atf_tests',
+    {
+      title: 'List ATF Tests',
+      description: [
+        'Lists/searches ATF tests (sys_atf_test), most recently updated first.',
+        "Use it to discover a test's sys_id, then read its steps with get_atf_test.",
+      ].join('\n'),
+      inputSchema: AtfListTests.shape,
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async ({ name_contains, active_only, limit }) => {
+      try {
+        const clauses: string[] = [];
+        if (active_only) clauses.push('active=true');
+        if (name_contains) clauses.push(`nameLIKE${name_contains}`);
+        clauses.push('ORDERBYDESCsys_updated_on');
+        const recs = await client.listRecords<SnRecord>(
+          TEST_TABLE,
+          clauses.join('^'),
+          ['sys_id', 'name', 'description', 'active', 'sys_updated_on'],
+          limit,
+        );
+
+        const rows = recs.map((r) => ({
+          sys_id: val(r, 'sys_id'),
+          name: disp(r, 'name'),
+          description: disp(r, 'description'),
+          active: val(r, 'active') === 'true',
+          updated: disp(r, 'sys_updated_on'),
+          url: recordUrl(client, TEST_TABLE, val(r, 'sys_id')),
+        }));
+
+        const summary = [
+          `${rows.length} test(s)${name_contains ? ` matching "${name_contains}"` : ''}:`,
+          '',
+          ...rows.map(
+            (r) =>
+              `• ${r.name}${r.active ? '' : ' (inactive)'} — ${r.sys_id} (updated ${r.updated})`,
+          ),
+        ].join('\n');
+
+        return {
+          content: [
+            { type: 'text' as const, text: summary },
+            { type: 'text' as const, text: JSON.stringify(rows, null, 2) },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  // ── Read: full test with steps ────────────────────────────────────────────
+  server.registerTool(
+    'get_atf_test',
+    {
+      title: 'Get ATF Test',
+      description: [
+        "Reads an ATF test (sys_atf_test) with its ordered steps and each step's",
+        'configured input values. Includes the test URL to open and run it in the UI.',
+      ].join('\n'),
+      inputSchema: AtfGetTest.shape,
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async ({ sys_id }) => {
+      try {
+        const test = await client.getRecord<SnRecord>(TEST_TABLE, sys_id);
+        const steps = await client.listRecords<SnRecord>(
+          STEP_TABLE,
+          `test=${sys_id}^ORDERBYorder`,
+          ['sys_id', 'order', 'step_config', 'active', 'description', 'table'],
+          200,
+        );
+
+        const stepValues = await Promise.all(
+          steps.map((s) =>
+            client.listRecords<SnRecord>(
+              VAR_VALUE_TABLE,
+              `document=${STEP_TABLE}^document_key=${val(s, 'sys_id')}^ORDERBYorder`,
+              // variable.element is the input's element key — what add_atf_step /
+              // update_atf_step take — vs. the variable's display label.
+              ['variable', 'variable.element', 'value', 'order'],
+              100,
+            ),
+          ),
+        );
+
+        const stepObjs = steps.map((s, idx) => ({
+          sys_id: val(s, 'sys_id'),
+          order: val(s, 'order'),
+          step_config: disp(s, 'step_config'),
+          active: val(s, 'active') === 'true',
+          table: disp(s, 'table'),
+          inputs: stepValues[idx].map((v) => ({
+            element: val(v, 'variable.element'),
+            variable: disp(v, 'variable'),
+            value: disp(v, 'value'),
+          })),
+        }));
+
+        const result = {
+          sys_id: val(test, 'sys_id'),
+          name: disp(test, 'name'),
+          description: disp(test, 'description'),
+          active: val(test, 'active') === 'true',
+          url: recordUrl(client, TEST_TABLE, sys_id),
+          steps: stepObjs,
+        };
+
+        const summary = [
+          `Test: ${result.name} (${result.sys_id})`,
+          `Active: ${result.active}`,
+          `URL:   ${result.url}`,
+          '',
+          `Steps (${stepObjs.length}):`,
+          ...stepObjs.flatMap((s) => [
+            `  ${s.order}. ${s.step_config}${s.active ? '' : ' (inactive)'} — ${s.sys_id}`,
+            ...s.inputs.map(
+              (i) =>
+                `       ${i.variable}${i.element ? ` [${i.element}]` : ''}: ${i.value}`,
+            ),
+          ]),
+        ].join('\n');
+
+        return {
+          content: [
+            { type: 'text' as const, text: summary },
+            { type: 'text' as const, text: JSON.stringify(result, null, 2) },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  // ── Write: create test suite ──────────────────────────────────────────────
+  server.registerTool(
+    'create_atf_test_suite',
+    {
+      title: 'Create ATF Test Suite',
+      description: [
+        'Creates an ATF test suite (sys_atf_test_suite). A suite groups tests so they',
+        'run together in order. Add tests with add_atf_test_to_suite.',
+        '',
+        'Returns the suite sys_id and URL.',
+      ].join('\n'),
+      inputSchema: AtfTestSuiteCreate.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async ({ name, description, active }) => {
+      try {
+        const body: Record<string, unknown> = { name, active: String(active) };
+        if (description !== undefined) body.description = description;
+        const created = await client.createRecord<SnRecord>(SUITE_TABLE, body);
+        const sysId = val(created, 'sys_id');
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: [
+                'Test suite created successfully.',
+                '',
+                `Name:   ${name}`,
+                `sys_id: ${sysId}`,
+                `URL:    ${recordUrl(client, SUITE_TABLE, sysId)}`,
+                '',
+                'Add tests to it with add_atf_test_to_suite.',
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  // ── Write: update test suite (incl. soft-delete via active=false) ──────────
+  server.registerTool(
+    'update_atf_test_suite',
+    {
+      title: 'Update ATF Test Suite',
+      description: [
+        'Updates an ATF test suite (sys_atf_test_suite). Pass only fields to change.',
+        'Set active=false to soft-delete the suite — there is no hard delete.',
+      ].join('\n'),
+      inputSchema: AtfTestSuiteUpdate.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({ sys_id, name, description, active }) => {
+      try {
+        if (!isSysId(sys_id)) {
+          return errText(`"${sys_id}" is not a valid test suite sys_id.`);
+        }
+        const body: Record<string, unknown> = {};
+        if (name !== undefined) body.name = name;
+        if (description !== undefined) body.description = description;
+        if (active !== undefined) body.active = String(active);
+        await client.patchRecord(SUITE_TABLE, sys_id, body);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: [
+                'Test suite updated successfully.',
+                '',
+                `sys_id:         ${sys_id}`,
+                `Updated fields: ${Object.keys(body).join(', ') || 'none'}`,
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  // ── Write: create test ────────────────────────────────────────────────────
+  server.registerTool(
+    'create_atf_test',
+    {
+      title: 'Create ATF Test',
+      description: [
+        'Creates an ATF test (sys_atf_test). Add steps with add_atf_step (in execution',
+        'order). To run it, open the returned URL in ServiceNow — this server does not',
+        'execute tests.',
+        '',
+        'Returns the test sys_id and URL.',
+      ].join('\n'),
+      inputSchema: AtfTestCreate.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async ({ name, description, active, enable_parameterized_testing }) => {
+      try {
+        const body: Record<string, unknown> = { name, active: String(active) };
+        if (description !== undefined) body.description = description;
+        if (enable_parameterized_testing !== undefined)
+          body.enable_parameterized_testing = String(
+            enable_parameterized_testing,
+          );
+        const created = await client.createRecord<SnRecord>(TEST_TABLE, body);
+        const sysId = val(created, 'sys_id');
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: [
+                'Test created successfully.',
+                '',
+                `Name:   ${name}`,
+                `sys_id: ${sysId}`,
+                `URL:    ${recordUrl(client, TEST_TABLE, sysId)}`,
+                '',
+                'Add steps with add_atf_step. Save the sys_id — each step needs it.',
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  // ── Write: update test (incl. soft-delete via active=false) ────────────────
+  server.registerTool(
+    'update_atf_test',
+    {
+      title: 'Update ATF Test',
+      description: [
+        'Updates an ATF test (sys_atf_test). Pass only fields to change.',
+        'Set active=false to soft-delete the test — there is no hard delete.',
+      ].join('\n'),
+      inputSchema: AtfTestUpdate.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({
+      sys_id,
+      name,
+      description,
+      active,
+      enable_parameterized_testing,
+    }) => {
+      try {
+        if (!isSysId(sys_id)) {
+          return errText(`"${sys_id}" is not a valid test sys_id.`);
+        }
+        const body: Record<string, unknown> = {};
+        if (name !== undefined) body.name = name;
+        if (description !== undefined) body.description = description;
+        if (active !== undefined) body.active = String(active);
+        if (enable_parameterized_testing !== undefined)
+          body.enable_parameterized_testing = String(
+            enable_parameterized_testing,
+          );
+        await client.patchRecord(TEST_TABLE, sys_id, body);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: [
+                'Test updated successfully.',
+                '',
+                `sys_id:         ${sys_id}`,
+                `Updated fields: ${Object.keys(body).join(', ') || 'none'}`,
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  // ── Write: add test to suite ──────────────────────────────────────────────
+  server.registerTool(
+    'add_atf_test_to_suite',
+    {
+      title: 'Add ATF Test to Suite',
+      description: [
+        'Adds a test to a test suite (creates a sys_atf_test_suite_test link with an',
+        'execution order). Requires the suite sys_id and the test sys_id.',
+      ].join('\n'),
+      inputSchema: AtfAddTestToSuite.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async ({ test_suite, test, order }) => {
+      try {
+        if (!isSysId(test_suite))
+          return errText(`"${test_suite}" is not a valid test suite sys_id.`);
+        if (!isSysId(test))
+          return errText(`"${test}" is not a valid test sys_id.`);
+        const resolvedOrder =
+          order ??
+          (await nextOrder(
+            client,
+            SUITE_TEST_TABLE,
+            `test_suite=${test_suite}`,
+          ));
+        const created = await client.createRecord<SnRecord>(SUITE_TEST_TABLE, {
+          test_suite,
+          test,
+          order: String(resolvedOrder),
+        });
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: [
+                'Test added to suite successfully.',
+                '',
+                `Link sys_id: ${val(created, 'sys_id')}`,
+                `Order:       ${resolvedOrder}`,
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  // ── Write: add a configured step to a test ─────────────────────────────────
+  server.registerTool(
+    'add_atf_step',
+    {
+      title: 'Add ATF Step',
+      description: [
+        'Adds a step to an ATF test (sys_atf_step) and configures its inputs in one',
+        'call. The step is created immediately (its sys_id is returned now); input',
+        'values are written by a server-side script and appear within a few seconds',
+        '(ServiceNow ACLs block writing them directly over the API).',
+        '',
+        'IMPORTANT — you MUST call get_atf_step_config_schema before this tool.',
+        'Element names are NOT guessable from UI labels: e.g. the "Record" field in',
+        '"Open an Existing Record" has element `record_id`, not `record`. Using a',
+        'wrong name will cause the tool to reject the input; omitting inputs entirely',
+        'creates the step unconfigured. Always derive element names from the schema.',
+        '',
+        'Each input targets one element of the step config. An input is either a',
+        'literal `value` or a dependency on an earlier step via `map_from_step`',
+        "(that step's sys_id) + `map_output` (an output element of its config).",
+        'The tool wires the dependency as the sys_id token form',
+        "`{{step['<producer sys_id>'].<output element>}}`, the same token the",
+        "UI's dot-walking picker writes. For whole-value maps into reference/",
+        'document_id fields (e.g. the "Record" field of Open an Existing Record)',
+        'it also writes the companion sys_element_mapping row that makes the token',
+        'resolve at runtime — handled automatically, no extra input needed.',
+        '',
+        'Build a test top-down: add producer steps first, then reference the sys_id',
+        'returned here as map_from_step on later steps. Returns the step sys_id and',
+        "the output elements the new step exposes. Inputs you omit are auto-filled with the config's",
+        'dictionary defaults (matching what the UI form saves); the tool warns when an',
+        'assert-type input remains empty, because such a step asserts nothing.',
+        '',
+        'Coverage patterns: after a submit/insert step, consume its outputs (e.g.',
+        'record_id) in a later server-side validation step. When verifying a',
+        'conditional UI state (e.g. a catalog UI policy), first assert the INITIAL',
+        'state with a state-validation step ordered BEFORE the step that triggers the',
+        'change — otherwise the test passes even if the state was always on.',
+      ].join('\n'),
+      inputSchema: AtfAddStep.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async ({ test, step_config, order, active, inputs }) => {
+      try {
+        if (!isSysId(test))
+          return errText(`"${test}" is not a valid test sys_id.`);
+
+        const { sysId: configSysId, name: configName } =
+          await resolveStepConfig(client, step_config);
+        const [defs, outputs, producers] = await Promise.all([
+          fetchInputDefs(client, configSysId),
+          fetchOutputDefs(client, configSysId),
+          fetchProducers(client, inputs),
+        ]);
+        // Validate/resolve inputs before creating the step so a bad input
+        // never leaves an orphan step behind.
+        const resolved = inputs?.length
+          ? resolveStepInputs(defs, inputs, producers)
+          : [];
+
+        // The UI pre-fills every input's dictionary default when the step form
+        // renders, so a manual save persists them; API-created steps must write
+        // them too or end up configured differently from UI-created ones (e.g.
+        // Record Insert's assert_type silently empty → the step asserts nothing).
+        // javascript: defaults are evaluated server-side at render time and
+        // can't be replayed here.
+        const provided = new Set(resolved.map((r) => r.element));
+        const defaulted = defs.filter(
+          (d) =>
+            !provided.has(d.element) &&
+            d.defaultValue !== '' &&
+            !d.defaultValue.startsWith('javascript:'),
+        );
+        const allResolved: ResolvedInput[] = [
+          ...resolved,
+          ...defaulted.map((d) => ({
+            element: d.element,
+            variableSysId: d.sysId,
+            value: d.defaultValue,
+            order: d.order,
+            needsElementMapping: false,
+          })),
+        ];
+
+        const resolvedOrder =
+          order ?? (await nextOrder(client, STEP_TABLE, `test=${test}`));
+
+        const body: Record<string, unknown> = {
+          test,
+          step_config: configSysId,
+          order: String(resolvedOrder),
+        };
+        if (active !== undefined) body.active = String(active);
+        // Denormalise the table column from a literal "table" input, matching OOTB steps.
+        const tableInput = inputs?.find(
+          (i) => i.element === 'table' && i.value,
+        );
+        if (tableInput?.value) body.table = tableInput.value;
+
+        const created = await client.createRecord<SnRecord>(STEP_TABLE, body);
+        const stepSysId = val(created, 'sys_id');
+
+        // sys_variable_value rejects REST writes (ACL); write inputs server-side
+        // via a +1s trigger, then read them back so we report what actually
+        // landed instead of optimistically assuming success.
+        let inputStatus = 'Inputs:      none';
+        let stored = new Map<string, string>();
+        if (allResolved.length) {
+          await client.executeBackgroundScriptTrigger(
+            buildInputUpsertScript(stepSysId, allResolved, configSysId),
+          );
+          const verified = await verifyInputsWritten(
+            client,
+            stepSysId,
+            allResolved,
+          );
+          stored = verified.stored;
+          inputStatus = formatInputStatus(verified.pending, allResolved);
+        }
+
+        const missingMandatory = defs.filter(
+          (d) =>
+            d.mandatory && !allResolved.some((r) => r.element === d.element),
+        );
+        const assertWarnings = buildAssertWarnings(defs, stored);
+        const defaultsLine = defaulted.length
+          ? `Defaults:    ${defaulted.map((d) => `${d.element}=${d.defaultValue}`).join(', ')} (from step config)`
+          : undefined;
+        const outputLines = outputs.length
+          ? [
+              `Outputs:     ${outputs.map((o) => `${o.element} [${o.internalType}]`).join(', ')}`,
+              `             Consume them in later steps via map_from_step=${stepSysId} + map_output`,
+              '             (e.g. a server-side record validation after a submit/insert).',
+            ]
+          : ['Outputs:     none'];
+
+        const schemaLines =
+          missingMandatory.length > 0
+            ? [
+                '',
+                `⚠ Mandatory inputs not yet set. Call update_atf_step with sys_id=${stepSysId}.`,
+                `Full schema for "${configName}" — use these element names exactly:`,
+                ...defs.map(
+                  (d) =>
+                    `  • ${d.element} (${d.label}) [${d.internalType}]${d.mandatory ? ' — MANDATORY' : ''}${d.reference ? ` → ${d.reference}` : ''}`,
+                ),
+              ]
+            : [];
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: [
+                'Step added successfully.',
+                '',
+                `Test:        ${test}`,
+                `Step config: ${configName}`,
+                `Order:       ${resolvedOrder}`,
+                `Step sys_id: ${stepSysId}`,
+                inputStatus,
+                defaultsLine,
+                ...outputLines,
+                ...assertWarnings,
+                ...schemaLines,
+              ]
+                .filter((l): l is string => l !== undefined)
+                .join('\n'),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  // ── Write: update a step (reorder / activate / change inputs) ──────────────
+  server.registerTool(
+    'update_atf_step',
+    {
+      title: 'Update ATF Step',
+      description: [
+        'Updates an existing ATF step (sys_atf_step): reorder, activate/deactivate, or',
+        'set/overwrite input values. Inputs are upserted by element — passing the same',
+        'element again overwrites its stored value. Set active=false to soft-disable.',
+      ].join('\n'),
+      inputSchema: AtfUpdateStep.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({ sys_id, order, active, inputs }) => {
+      try {
+        if (!isSysId(sys_id))
+          return errText(`"${sys_id}" is not a valid step sys_id.`);
+
+        const step = await client.getRecord<SnRecord>(STEP_TABLE, sys_id, [
+          'sys_id',
+          'step_config',
+        ]);
+        const configSysId = val(step, 'step_config');
+
+        const body: Record<string, unknown> = {};
+        if (order !== undefined) body.order = String(order);
+        if (active !== undefined) body.active = String(active);
+        const tableInput = inputs?.find(
+          (i) => i.element === 'table' && i.value,
+        );
+        if (tableInput?.value) body.table = tableInput.value;
+        if (Object.keys(body).length > 0) {
+          await client.patchRecord(STEP_TABLE, sys_id, body);
+        }
+
+        let inputStatus = 'Inputs:         none';
+        let assertWarnings: string[] = [];
+        if (inputs?.length) {
+          const [defs, producers] = await Promise.all([
+            fetchInputDefs(client, configSysId),
+            fetchProducers(client, inputs),
+          ]);
+          const resolved = resolveStepInputs(defs, inputs, producers);
+          // sys_variable_value rejects REST writes (ACL); write server-side via a
+          // +1s trigger, then read back to confirm what actually landed.
+          await client.executeBackgroundScriptTrigger(
+            buildInputUpsertScript(sys_id, resolved, configSysId),
+          );
+          const verified = await verifyInputsWritten(client, sys_id, resolved);
+          inputStatus = formatInputStatus(verified.pending, resolved);
+          // The readback covers ALL of the step's values, so this flags assert
+          // inputs that were empty before this update too, not just ones the
+          // caller blanked now.
+          assertWarnings = buildAssertWarnings(defs, verified.stored);
+        }
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: [
+                'Step updated successfully.',
+                '',
+                `Step sys_id:    ${sys_id}`,
+                `Updated fields: ${Object.keys(body).join(', ') || 'none'}`,
+                inputStatus,
+                ...assertWarnings,
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+}
+
+function errText(text: string) {
+  return {
+    content: [{ type: 'text' as const, text }],
+    isError: true,
+  };
+}

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -1149,3 +1149,256 @@ export const BusinessRuleUpdate = BusinessRuleBase.partial().extend({
     .min(1)
     .describe('sys_id of the sys_script record to update.'),
 });
+
+// ── ATF (Automated Test Framework) ──────────────────────────────────────────────
+
+export const AtfListStepConfigs = z.object({
+  name_contains: z
+    .string()
+    .optional()
+    .describe(
+      'Case-insensitive substring to filter step config names, e.g. "Record" or "Open".',
+    ),
+  category: z
+    .string()
+    .optional()
+    .describe(
+      'Filter by category label, e.g. "Server", "Form", "Service Catalog", "REST". ' +
+        'Matches the sys_atf_step_config_category name.',
+    ),
+  active_only: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe(
+      'Only return active, non-deprecated step configs. Defaults to true.',
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(200)
+    .optional()
+    .default(100)
+    .describe(
+      'Maximum number of step configs to return (1–200). Defaults to 100.',
+    ),
+});
+
+export const AtfGetStepConfigSchema = z.object({
+  step_config: z
+    .string()
+    .min(1)
+    .describe(
+      'sys_id OR exact name of the step config (sys_atf_step_config), ' +
+        'e.g. "Record Insert" or its 32-char sys_id. Call list_atf_step_configs to discover names.',
+    ),
+});
+
+export const AtfGetTest = z.object({
+  sys_id: z
+    .string()
+    .min(1)
+    .describe(
+      'sys_id of the test (sys_atf_test) to read with its ordered steps.',
+    ),
+});
+
+export const AtfListTests = z.object({
+  name_contains: z
+    .string()
+    .optional()
+    .describe(
+      'Case-insensitive substring to filter test names, e.g. "Connectivity".',
+    ),
+  active_only: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe('Only return active tests. Defaults to true.'),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .default(20)
+    .describe('Maximum number of tests to return (1–100). Defaults to 20.'),
+});
+
+// ── ATF Test Suite ──
+
+const AtfTestSuiteBase = z.object({
+  name: z.string().min(1).describe('Display name of the test suite.'),
+  description: z
+    .string()
+    .optional()
+    .describe('Plain-text description of what the suite covers.'),
+  active: z
+    .boolean()
+    .optional()
+    .describe(
+      'Whether the suite is active. Set false to soft-delete (there is no hard delete).',
+    ),
+});
+
+export const AtfTestSuiteCreate = AtfTestSuiteBase.extend({
+  active: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe('Whether the suite is active. Defaults to true.'),
+});
+
+export const AtfTestSuiteUpdate = AtfTestSuiteBase.partial().extend({
+  sys_id: z
+    .string()
+    .min(1)
+    .describe('sys_id of the test suite (sys_atf_test_suite) to update.'),
+});
+
+// ── ATF Test ──
+
+const AtfTestBase = z.object({
+  name: z.string().min(1).describe('Display name of the test.'),
+  description: z
+    .string()
+    .optional()
+    .describe('Plain-text description of what the test verifies.'),
+  active: z
+    .boolean()
+    .optional()
+    .describe(
+      'Whether the test is active. Set false to soft-delete (there is no hard delete).',
+    ),
+  enable_parameterized_testing: z
+    .boolean()
+    .optional()
+    .describe(
+      'Enables data-driven (parameterized) testing on this test. Leave unset unless requested.',
+    ),
+});
+
+export const AtfTestCreate = AtfTestBase.extend({
+  active: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe('Whether the test is active. Defaults to true.'),
+});
+
+export const AtfTestUpdate = AtfTestBase.partial().extend({
+  sys_id: z
+    .string()
+    .min(1)
+    .describe('sys_id of the test (sys_atf_test) to update.'),
+});
+
+export const AtfAddTestToSuite = z.object({
+  test_suite: z
+    .string()
+    .min(1)
+    .describe('sys_id of the test suite (sys_atf_test_suite).'),
+  test: z.string().min(1).describe('sys_id of the test (sys_atf_test) to add.'),
+  order: z
+    .number()
+    .int()
+    .optional()
+    .describe(
+      'Execution order of this test within the suite. Defaults to the next multiple of 100.',
+    ),
+});
+
+// ── ATF Step + inputs ──
+
+const AtfStepInput = z.object({
+  element: z
+    .string()
+    .min(1)
+    .describe(
+      'The input key (element) on the step config, e.g. "table", "field_values", "record". ' +
+        'Call get_atf_step_config_schema to list the valid elements and their types.',
+    ),
+  value: z
+    .string()
+    .optional()
+    .describe(
+      'Literal value for this input, formatted for its internal_type: ' +
+        'table_name/string/choice = plain text; reference/document_id = a 32-char sys_id; ' +
+        'template_value/condition = an encoded query like "field=value^EQ". ' +
+        'For catalog variable_template_value (Set Variable Values SP) it is ' +
+        '"IO:<item_option_new_sysid>=<stored_value>^...^EQ", where <stored_value> is the ' +
+        "variable's STORED value, NOT its label — derive it, do not guess: Yes/No vars store " +
+        '"Yes"/"No" (not true/false), Select Box stores the choice value (not its text), ' +
+        'reference stores a sys_id, Date/Time uses "YYYY-MM-DD HH:MM:SS". When a UI policy ' +
+        "depends on the variable, read the policy's raw catalog_conditions (catalog_ui_policy) — " +
+        'it already contains the exact value to match. ' +
+        'To embed a previous step output inside an encoded query, include the token ' +
+        "{{step['<step_sys_id>'].<output_element>}}, e.g. \"caller_id={{step['abc...'].user}}^EQ\". " +
+        'Assert-type choice inputs (e.g. assert_type) left empty make the step assert ' +
+        'NOTHING — always set them explicitly. ' +
+        'Mutually exclusive with map_from_step.',
+    ),
+  map_from_step: z
+    .string()
+    .optional()
+    .describe(
+      'sys_id of an earlier sys_atf_step whose output feeds this input (whole-value mapping). ' +
+        "When set, the value becomes the token {{step['<map_from_step>'].<map_output>}}. " +
+        'Pair with map_output. Mutually exclusive with value.',
+    ),
+  map_output: z
+    .string()
+    .optional()
+    .describe(
+      'The output element on the producing step config to map from, e.g. "record_id", "table", "user". ' +
+        'Call get_atf_step_config_schema on the producing step config to list outputs. Required with map_from_step.',
+    ),
+});
+
+const AtfStepBase = z.object({
+  order: z
+    .number()
+    .int()
+    .optional()
+    .describe(
+      'Execution order of the step within the test. Defaults to the next multiple of 100 ' +
+        '(appends at the end). To INSERT a step between existing ones — e.g. a pre-condition ' +
+        'state validation BEFORE the step that mutates state — pass an order between the ' +
+        "neighbouring steps' orders (orders are spaced by 100, so there is always room).",
+    ),
+  active: z
+    .boolean()
+    .optional()
+    .describe(
+      'Whether the step is active. Set false to soft-disable the step.',
+    ),
+  inputs: z
+    .array(AtfStepInput)
+    .optional()
+    .describe(
+      'Input values for the step. Each entry targets one element of the step config. ' +
+        'Omit to create the step without configured inputs (configure later via update_atf_step).',
+    ),
+});
+
+export const AtfAddStep = AtfStepBase.extend({
+  test: z
+    .string()
+    .min(1)
+    .describe('sys_id of the test (sys_atf_test) this step belongs to.'),
+  step_config: z
+    .string()
+    .min(1)
+    .describe(
+      'sys_id OR exact name of the step config (sys_atf_step_config) that defines this step type, ' +
+        'e.g. "Record Insert". Call list_atf_step_configs / get_atf_step_config_schema first.',
+    ),
+});
+
+export const AtfUpdateStep = AtfStepBase.extend({
+  sys_id: z
+    .string()
+    .min(1)
+    .describe('sys_id of the step (sys_atf_step) to update.'),
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Only run TypeScript sources. The compiled output in build/ contains
+    // duplicate .test.js files whose .json fixtures are not copied by tsc,
+    // so they must never be collected as tests.
+    include: ['src/**/*.test.ts'],
+    exclude: ['build/**', 'node_modules/**'],
+  },
+});


### PR DESCRIPTION
## What this changes

Adds a full ATF tool suite: create/update tests and suites, add/update steps, list step configs and their input/output schema, and list/get tests. Includes vitest setup and unit tests covering the main `add_atf_step` paths (input validation, step dependencies, choice resolution, output mapping).

## How it was verified

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test` passing
- [x] Exercised against a live ServiceNow PDI (for tool changes)

## Notes

Anything reviewers should know — trade-offs, follow-ups, breaking changes.
