### PR TITLE
feat: per-request access enforcement behind ACCESS_ENFORCEMENT flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,7 @@ TRANSPORT=http        # http (default) or stdio
 # Advanced: credential provider (default: env for local dev)
 # CREDENTIAL_PROVIDER=env
 # GATEWAY_SECRET=...  # required when CREDENTIAL_PROVIDER=header
+
+# Per-request access enforcement (gateway mode only; env/stdio always behaves as write)
+# ACCESS_ENFORCEMENT=off   # 'on' = write tools require the access header per request (default-deny)
+# ACCESS_HEADER=x-mcp-access

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,8 @@ No hook enforces this — it is entirely your responsibility. Skipping step 1 me
 | `TRANSPORT` | ❌ | `http` (default) or `stdio` |
 | `CREDENTIAL_PROVIDER` | ❌ | `env` (dev default) or `header` (gateway mode) |
 | `GATEWAY_SECRET` | ❌ | Required when `CREDENTIAL_PROVIDER=header` |
+| `ACCESS_ENFORCEMENT` | ❌ | `on` or `off` (default). Gateway mode only: write tools require the access header per request (default-deny). Env/stdio always behaves as write. |
+| `ACCESS_HEADER` | ❌ | Header carrying per-request access (default `x-mcp-access`) |
 
 ¹ Required when `SN_AUTH_TYPE=basic` or `SN_GRANT_TYPE=password`  
 ² Required when `SN_AUTH_TYPE=oauth`

--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ Copy `.env.example` to `.env` to configure.
 | `CREDENTIAL_PROVIDER` | ❌ | `env` | `env` (dev) or `header` (gateway mode) |
 | `GATEWAY_SECRET` | ❌ | — | Required when `CREDENTIAL_PROVIDER=header` |
 | `ALLOWED_ORIGIN` | ❌ | `*` in dev | CORS origin for HTTP transport |
+| `ACCESS_ENFORCEMENT` | ❌ | `off` | `on` or `off`. Gateway mode only: when `on`, write tools require the access header with value `write` on each request (default-deny). Env/stdio servers always behave as write. |
+| `ACCESS_HEADER` | ❌ | `x-mcp-access` | Header carrying the per-request access value (`write` grants write; anything else is read) |
 
 ¹ Required when `SN_AUTH_TYPE=basic` or `SN_GRANT_TYPE=password`  
 ² Required when `SN_AUTH_TYPE=oauth`

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -47,6 +47,14 @@ if (!validProviders.includes(rawProvider as CredentialProviderType)) {
 
 const snGrantType = optional('SN_GRANT_TYPE', 'password');
 
+const rawEnforcement = optional('ACCESS_ENFORCEMENT', 'off');
+if (rawEnforcement !== 'on' && rawEnforcement !== 'off') {
+  console.error(
+    `[config] Invalid ACCESS_ENFORCEMENT "${rawEnforcement}". Must be one of: on, off`,
+  );
+  process.exit(1);
+}
+
 export const config = {
   port: optionalInt('PORT', 3000),
   transport,
@@ -66,4 +74,8 @@ export const config = {
 
   credentialProvider: rawProvider as CredentialProviderType,
   gatewaySecret: optional('GATEWAY_SECRET', ''),
+
+  accessEnforcement: rawEnforcement as 'on' | 'off',
+  // Node lowercases incoming header names; keep the lookup key consistent.
+  accessHeader: optional('ACCESS_HEADER', 'x-mcp-access').toLowerCase(),
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,10 @@ import {
 import { log } from './logger.js';
 import { buildServer } from './server.js';
 import { sessionStore } from './session-store.js';
+import {
+  deriveEnforcement,
+  type ToolRegistryOptions,
+} from './tools/registry.js';
 
 function buildSnConfig(): ServiceNowConfig {
   const result = serviceNowConfigSchema.safeParse({
@@ -63,6 +67,14 @@ function createCredentialProvider(): CredentialProvider {
 
 const credentialProvider = createCredentialProvider();
 const DEV_MODE = config.credentialProvider === 'env';
+
+const registryOptions: ToolRegistryOptions = {
+  enforcement: deriveEnforcement(
+    config.credentialProvider,
+    config.accessEnforcement,
+  ),
+  accessHeader: config.accessHeader,
+};
 
 async function resolveCredentials(
   req: IncomingMessage,
@@ -169,7 +181,10 @@ async function handleMcpRequest(
     },
   });
 
-  const { server } = buildServer(new ServiceNowClient(credentials));
+  const { server } = buildServer(
+    new ServiceNowClient(credentials),
+    registryOptions,
+  );
 
   transport.onclose = () => {
     if (resolvedSessionId) {
@@ -251,6 +266,10 @@ async function startHttpServer(): Promise<void> {
     log('INFO', `HTTP server listening on port ${config.port}`);
     log('INFO', `MCP endpoint: http://localhost:${config.port}/mcp`);
     log('INFO', `Health check: http://localhost:${config.port}/health`);
+    log('INFO', 'Access enforcement mode resolved', {
+      mode: registryOptions.enforcement,
+      accessHeader: registryOptions.accessHeader,
+    });
     if (DEV_MODE) {
       log('INFO', 'DEV MODE active — JWT auth disabled');
       log('INFO', `Instance: ${config.sn.instance}`);
@@ -278,7 +297,10 @@ async function startHttpServer(): Promise<void> {
 }
 
 async function startStdioServer(): Promise<void> {
-  const { server } = buildServer(new ServiceNowClient(buildSnConfig()));
+  // Stdio has no per-request headers — always behaves as write.
+  const { server } = buildServer(new ServiceNowClient(buildSnConfig()), {
+    enforcement: 'off',
+  });
   const transport = new StdioServerTransport();
   await server.connect(transport);
   log('INFO', 'Running in stdio mode');

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,18 +8,21 @@ import { registerCatalogReadTools } from './tools/catalog-read.js';
 import { registerCatalogWriteTools } from './tools/catalog-write.js';
 import { registerFixScriptTools } from './tools/fix-script.js';
 import { registerRecordProducerTools } from './tools/record-producer.js';
-import { ToolRegistry } from './tools/registry.js';
+import { ToolRegistry, type ToolRegistryOptions } from './tools/registry.js';
 import { registerScriptIncludeTools } from './tools/script-include.js';
 import { registerTableCrudTools } from './tools/table-crud.js';
 import { registerUiPolicyTools } from './tools/ui-policy-write.js';
 import { registerUpdateSetTools } from './tools/update-sets.js';
 
-export function buildServer(snClient: ServiceNowClient): {
+export function buildServer(
+  snClient: ServiceNowClient,
+  registryOptions?: ToolRegistryOptions,
+): {
   server: McpServer;
   registry: ToolRegistry;
 } {
   const server = new McpServer({ name: 'servicenow-mcp', version: '0.1.0' });
-  const registry = new ToolRegistry(server);
+  const registry = new ToolRegistry(server, registryOptions);
 
   registerCatalogReadTools(registry, snClient);
   registerCatalogWriteTools(registry, snClient);

--- a/src/tests/helpers.ts
+++ b/src/tests/helpers.ts
@@ -2,16 +2,17 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ServiceNowClient } from '../clients/servicenow.js';
-import { ToolRegistry } from '../tools/registry.js';
+import { ToolRegistry, type ToolRegistryOptions } from '../tools/registry.js';
 
 export async function buildTestPair(
   registerFn: (registry: ToolRegistry, client: ServiceNowClient) => void,
   mockClient: ServiceNowClient,
+  registryOptions?: ToolRegistryOptions,
 ): Promise<{ mcpClient: Client; teardown: () => Promise<void> }> {
   const [serverTransport, clientTransport] =
     InMemoryTransport.createLinkedPair();
   const server = new McpServer({ name: 'test-sn', version: '0.0.0' });
-  registerFn(new ToolRegistry(server), mockClient);
+  registerFn(new ToolRegistry(server, registryOptions), mockClient);
   const mcpClient = new Client({ name: 'test-client', version: '1.0.0' });
   await server.connect(serverTransport);
   await mcpClient.connect(clientTransport);

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -1,8 +1,20 @@
-import { describe, expect, it } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type {
+  McpServer,
+  RegisteredTool,
+} from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import type { ServiceNowClient } from '../clients/servicenow.js';
 import { buildServer } from '../server.js';
 import { buildTestPair, firstText } from '../tests/helpers.js';
+import {
+  deriveEnforcement,
+  type ToolAccess,
+  ToolRegistry,
+  type ToolRegistryOptions,
+} from './registry.js';
 
 describe('tool access classification', () => {
   it('classifies every registered tool as read or write', () => {
@@ -119,5 +131,217 @@ describe('ToolRegistry', () => {
     expect(firstText(result)).toBe('hello');
 
     await teardown();
+  });
+});
+
+describe('deriveEnforcement', () => {
+  it('maps credential mode + flag to the enforcement mode', () => {
+    expect(deriveEnforcement('header', 'on')).toBe('enforce');
+    expect(deriveEnforcement('header', 'off')).toBe('observe');
+    expect(deriveEnforcement('env', 'on')).toBe('off');
+    expect(deriveEnforcement('env', 'off')).toBe('off');
+  });
+});
+
+describe('per-request access enforcement', () => {
+  const okResult = { content: [{ type: 'text' as const, text: 'ok' }] };
+
+  /**
+   * Registers a single tool through a stub McpServer that captures the
+   * wrapped handler, so tests can invoke it with a fabricated `extra` arg.
+   */
+  function captureWrapped(options: ToolRegistryOptions, access: ToolAccess) {
+    let wrapped: (...args: unknown[]) => unknown = () => {
+      throw new Error('tool was never registered');
+    };
+    const server = {
+      registerTool: (
+        _name: string,
+        _config: unknown,
+        cb: (...args: unknown[]) => unknown,
+      ) => {
+        wrapped = cb;
+        return {} as RegisteredTool;
+      },
+    } as unknown as McpServer;
+
+    const underlying = vi.fn(async () => okResult);
+    new ToolRegistry(server, options).registerTool(
+      'probe',
+      { access },
+      underlying,
+    );
+    return { call: (extra?: unknown) => wrapped(extra), underlying };
+  }
+
+  const grantedExtra = {
+    sessionId: 'sess-1',
+    requestInfo: { headers: { 'x-mcp-access': 'write' } },
+  };
+
+  it('enforcement off: write tool executes regardless of header', async () => {
+    for (const extra of [
+      grantedExtra,
+      { sessionId: 'sess-1', requestInfo: { headers: {} } },
+      { sessionId: 'sess-1' },
+      undefined,
+    ]) {
+      const { call, underlying } = captureWrapped(
+        { enforcement: 'off' },
+        'write',
+      );
+      expect(await call(extra)).toEqual(okResult);
+      expect(underlying).toHaveBeenCalledOnce();
+    }
+  });
+
+  it('enforce: header "write" grants the call', async () => {
+    const { call, underlying } = captureWrapped(
+      { enforcement: 'enforce' },
+      'write',
+    );
+    expect(await call(grantedExtra)).toEqual(okResult);
+    expect(underlying).toHaveBeenCalledOnce();
+  });
+
+  it('enforce: default-deny for missing header, "read", junk, multi-value, missing requestInfo, missing extra', async () => {
+    const deniedExtras: unknown[] = [
+      { sessionId: 'sess-1', requestInfo: { headers: {} } },
+      {
+        sessionId: 'sess-1',
+        requestInfo: { headers: { 'x-mcp-access': 'read' } },
+      },
+      {
+        sessionId: 'sess-1',
+        requestInfo: { headers: { 'x-mcp-access': 'admin; write' } },
+      },
+      {
+        sessionId: 'sess-1',
+        requestInfo: { headers: { 'x-mcp-access': ['write', 'write'] } },
+      },
+      { sessionId: 'sess-1' }, // no requestInfo
+      undefined, // no extra at all
+    ];
+
+    for (const extra of deniedExtras) {
+      const { call, underlying } = captureWrapped(
+        { enforcement: 'enforce' },
+        'write',
+      );
+      const result = (await call(extra)) as {
+        isError?: boolean;
+        content: Array<{ text: string }>;
+      };
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('requires write access');
+      expect(underlying).not.toHaveBeenCalled();
+    }
+  });
+
+  it('enforce: read tools are never gated', async () => {
+    const { call, underlying } = captureWrapped(
+      { enforcement: 'enforce' },
+      'read',
+    );
+    expect(await call({ sessionId: 'sess-1' })).toEqual(okResult);
+    expect(underlying).toHaveBeenCalledOnce();
+  });
+
+  it('observe: write tool executes without the header (pre-flip logging mode)', async () => {
+    const { call, underlying } = captureWrapped(
+      { enforcement: 'observe' },
+      'write',
+    );
+    expect(await call({ sessionId: 'sess-1' })).toEqual(okResult);
+    expect(underlying).toHaveBeenCalledOnce();
+  });
+
+  it('env mode derives "off" and writes work', async () => {
+    const { call, underlying } = captureWrapped(
+      { enforcement: deriveEnforcement('env', 'on') },
+      'write',
+    );
+    expect(await call({ sessionId: 'sess-1' })).toEqual(okResult);
+    expect(underlying).toHaveBeenCalledOnce();
+  });
+
+  it('respects a custom access header name', async () => {
+    const { call, underlying } = captureWrapped(
+      { enforcement: 'enforce', accessHeader: 'x-custom-access' },
+      'write',
+    );
+    expect(
+      await call({ requestInfo: { headers: { 'x-custom-access': 'write' } } }),
+    ).toEqual(okResult);
+    expect(underlying).toHaveBeenCalledOnce();
+  });
+});
+
+describe('enforcement wiring through buildServer', () => {
+  async function connect(server: McpServer) {
+    const [serverTransport, clientTransport] =
+      InMemoryTransport.createLinkedPair();
+    const mcpClient = new Client({ name: 'test-client', version: '1.0.0' });
+    await server.connect(serverTransport);
+    await mcpClient.connect(clientTransport);
+    return mcpClient;
+  }
+
+  it('enforce mode denies a write tool call before the client is touched', async () => {
+    // The in-memory transport carries no requestInfo — exactly the
+    // default-deny path a gateway request without the header hits.
+    const createRecord = vi.fn();
+    const { server } = buildServer(
+      { createRecord } as unknown as ServiceNowClient,
+      { enforcement: 'enforce' },
+    );
+    const mcpClient = await connect(server);
+
+    const result = await mcpClient.callTool({
+      name: 'create_record',
+      arguments: { table: 'incident', data: { short_description: 'x' } },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(firstText(result)).toContain('requires write access');
+    expect(createRecord).not.toHaveBeenCalled();
+    await mcpClient.close();
+  });
+
+  it('enforce mode leaves read tools callable', async () => {
+    const listRecords = vi.fn(async () => []);
+    const { server } = buildServer(
+      { listRecords } as unknown as ServiceNowClient,
+      { enforcement: 'enforce' },
+    );
+    const mcpClient = await connect(server);
+
+    const result = await mcpClient.callTool({
+      name: 'query_records',
+      arguments: { table: 'incident' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(listRecords).toHaveBeenCalledOnce();
+    await mcpClient.close();
+  });
+
+  it('enforcement off keeps write tools working end-to-end', async () => {
+    const createRecord = vi.fn(async () => ({ sys_id: { value: 'abc123' } }));
+    const { server } = buildServer(
+      { createRecord } as unknown as ServiceNowClient,
+      { enforcement: 'off' },
+    );
+    const mcpClient = await connect(server);
+
+    const result = await mcpClient.callTool({
+      name: 'create_record',
+      arguments: { table: 'incident', data: { short_description: 'x' } },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(firstText(result)).toContain('abc123');
+    expect(createRecord).toHaveBeenCalledOnce();
+    await mcpClient.close();
   });
 });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -8,6 +8,7 @@ import type {
   ZodRawShapeCompat,
 } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import { log } from '../logger.js';
 
 /**
  * Access classification for a tool.
@@ -17,6 +18,49 @@ import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
  * to read data. When in doubt, classify as 'write' (fail-closed).
  */
 export type ToolAccess = 'read' | 'write';
+
+/**
+ * - 'enforce' — gateway mode with ACCESS_ENFORCEMENT=on: write tools deny
+ *   unless the current request carries the access header with value 'write'.
+ * - 'observe' — gateway mode with the flag off: passthrough, but log the
+ *   resolved access per write-tool call so prod logs prove the header
+ *   arrives correctly before the flip.
+ * - 'off' — env/stdio mode: passthrough, no logging (no gateway headers).
+ */
+export type AccessEnforcementMode = 'enforce' | 'observe' | 'off';
+
+export type ToolRegistryOptions = {
+  enforcement: AccessEnforcementMode;
+  /** Lowercase header name carrying the access value. */
+  accessHeader?: string;
+};
+
+/**
+ * Maps deploy-time config to the registry's enforcement mode. Enforcement is
+ * only meaningful in gateway mode (header credentials); env/stdio servers
+ * always behave as write regardless of the flag.
+ */
+export function deriveEnforcement(
+  credentialProvider: 'env' | 'header',
+  flag: 'on' | 'off',
+): AccessEnforcementMode {
+  if (credentialProvider !== 'header') return 'off';
+  return flag === 'on' ? 'enforce' : 'observe';
+}
+
+const DEFAULT_ACCESS_HEADER = 'x-mcp-access';
+
+const DENIED_MESSAGE =
+  'This tool requires write access, which has not been granted for this ' +
+  'request. Present a plan and get user approval first.';
+
+/** Minimal view of the SDK's RequestHandlerExtra — always the handler's last arg. */
+type HandlerExtra = {
+  sessionId?: string;
+  requestInfo?: {
+    headers?: Record<string, string | string[] | undefined>;
+  };
+};
 
 type ToolConfig<
   OutputArgs extends ZodRawShapeCompat | AnySchema,
@@ -40,8 +84,16 @@ type ToolConfig<
  */
 export class ToolRegistry {
   private readonly access = new Map<string, ToolAccess>();
+  private readonly enforcement: AccessEnforcementMode;
+  private readonly accessHeader: string;
 
-  constructor(private readonly server: McpServer) {}
+  constructor(
+    private readonly server: McpServer,
+    options: ToolRegistryOptions = { enforcement: 'off' },
+  ) {
+    this.enforcement = options.enforcement;
+    this.accessHeader = options.accessHeader ?? DEFAULT_ACCESS_HEADER;
+  }
 
   registerTool<
     OutputArgs extends ZodRawShapeCompat | AnySchema,
@@ -65,20 +117,58 @@ export class ToolRegistry {
   }
 
   /**
-   * Every tool handler routes through here. A passthrough today: the
-   * per-request access check (X-MCP-Access header, call-time default-deny)
-   * will be added here without touching any registration site.
+   * Every tool handler routes through here. Sessions outlive requests
+   * (buildServer runs once per session) while the access grant is
+   * per-request, so this check must read the *live* request's headers from
+   * the handler's `extra` arg on every call — never session-creation state.
+   * Default-deny: only an access header of exactly 'write' grants write;
+   * missing header, malformed value, or missing requestInfo all resolve to
+   * read. Read tools are never gated.
    */
   private wrapHandler<
     InputArgs extends undefined | ZodRawShapeCompat | AnySchema,
   >(
-    _name: string,
-    _access: ToolAccess,
+    name: string,
+    access: ToolAccess,
     cb: ToolCallback<InputArgs>,
   ): ToolCallback<InputArgs> {
     const handler = cb as (...args: unknown[]) => unknown;
-    return ((...args: unknown[]) =>
-      handler(...args)) as ToolCallback<InputArgs>;
+    return ((...args: unknown[]) => {
+      if (access === 'write' && this.enforcement !== 'off') {
+        const extra = args.at(-1) as HandlerExtra | undefined;
+        const granted = this.resolveAccess(extra);
+        const sessionId = extra?.sessionId ?? '(none)';
+
+        if (this.enforcement === 'enforce') {
+          if (granted !== 'write') {
+            log('WARN', 'Write tool call denied — write access not granted', {
+              tool: name,
+              sessionId,
+            });
+            return {
+              isError: true,
+              content: [{ type: 'text' as const, text: DENIED_MESSAGE }],
+            };
+          }
+        } else {
+          log('DBG', 'Resolved access for write-tool call (enforcement off)', {
+            tool: name,
+            access: granted,
+            sessionId,
+          });
+        }
+      }
+      return handler(...args);
+    }) as ToolCallback<InputArgs>;
+  }
+
+  private resolveAccess(extra: HandlerExtra | undefined): ToolAccess {
+    const headers = extra?.requestInfo?.headers;
+    if (!headers) return 'read';
+    const raw = headers[this.accessHeader];
+    return typeof raw === 'string' && raw.trim().toLowerCase() === 'write'
+      ? 'write'
+      : 'read';
   }
 
   /** Tool name → access classification, sorted by name. */


### PR DESCRIPTION
## What this changes

Implements call-time access enforcement in `ToolRegistry.wrapHandler` (previously a passthrough). When enforcement is on (gateway mode + `ACCESS_ENFORCEMENT=on`), write tools execute only if the current request carries the access header (`X-MCP-Access` by default) with value `write`.

Sessions are reused across requests while the access grant arrives per request, so the check reads `RequestHandlerExtra.requestInfo.headers` on every `tools/call` — never session-creation state. Default-deny explicitly covers the **missing-header**, **malformed-header** (`read`, junk, multi-value arrays), and **missing-`requestInfo`** cases — all resolve to read. **Read tools are unaffected** — they are never gated in any mode.

Staged rollout: with `ACCESS_ENFORCEMENT=off` (default) behavior is byte-identical to today; in gateway mode the registry DBG-logs the resolved access per write-tool call so prod logs prove the header arrives correctly before the flip. Denied calls return a tool error result (`isError: true`) with a model-actionable message — not a protocol error — and are WARN-logged with tool name and session id. Env/stdio servers always behave as write, regardless of the flag.

Registration is deliberately not filtered by access: a session created on a read turn must still expose write tools for a later write-granted request. Listing-time filtering can come later if e2e shows clients never reuse sessions across access changes.

## How it was verified

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test` passing — 259 tests; the tool-surface inline snapshot is unchanged
- [x] Exercised end-to-end over real HTTP (`StreamableHTTPServerTransport`, gateway mode): on a single reused session, `create_record` denied with no header and with `x-mcp-access: read`, allowed with `x-mcp-access: write`; `query_records` ungated; WARN/DBG logs emitted in both enforce and observe modes

## Notes

- New unit tests cover every deny path, the grant path, observe mode, env-mode derivation, and a custom header name; integration tests through `buildServer` prove a denied call never reaches the ServiceNow client.
- Follow-up candidate: listing-time tool filtering, pending e2e evidence on client session-reuse behavior across access changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)