### PR TITLE
feat: toolset-scoped tool-surface filtering via X-MCP-Toolsets header

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ No hook enforces this — it is entirely your responsibility. Skipping step 1 me
 | `GATEWAY_SECRET` | ❌ | Required when `CREDENTIAL_PROVIDER=header` |
 | `ACCESS_ENFORCEMENT` | ❌ | `on` or `off` (default). Gateway mode only: write tools require the access header per request (default-deny). Env/stdio always behaves as write. |
 | `ACCESS_HEADER` | ❌ | Header carrying per-request access (default `x-mcp-access`) |
+| `TOOLSETS_HEADER` | ❌ | Header naming the toolsets (domain folders) a new session registers, comma-separated (default `x-mcp-toolsets`). Gateway mode only; fail-open UX scoping, not a security boundary. |
 
 ¹ Required when `SN_AUTH_TYPE=basic` or `SN_GRANT_TYPE=password`  
 ² Required when `SN_AUTH_TYPE=oauth`

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Copy `.env.example` to `.env` to configure.
 | `ALLOWED_ORIGIN` | ❌ | `*` in dev | CORS origin for HTTP transport |
 | `ACCESS_ENFORCEMENT` | ❌ | `off` | `on` or `off`. Gateway mode only: when `on`, write tools require the access header with value `write` on each request (default-deny). Env/stdio servers always behave as write. |
 | `ACCESS_HEADER` | ❌ | `x-mcp-access` | Header carrying the per-request access value (`write` grants write; anything else is read) |
+| `TOOLSETS_HEADER` | ❌ | `x-mcp-toolsets` | Header naming the toolsets a new session registers (gateway mode only) — see [Gateway headers](#gateway-headers) |
 
 ¹ Required when `SN_AUTH_TYPE=basic` or `SN_GRANT_TYPE=password`  
 ² Required when `SN_AUTH_TYPE=oauth`
@@ -297,6 +298,13 @@ For production self-hosting:
 - Run behind a reverse proxy (nginx, Caddy, Railway, Fly.io)
 - Use `TRANSPORT=http` (default) for remote deployments
 - Health check: `GET /health`
+
+### Gateway headers
+
+In gateway mode (`CREDENTIAL_PROVIDER=header`) the server trusts two headers set by the proxy in front of it. They are only meaningful behind an authenticating proxy that sets them itself and strips any client-supplied values — never expose the server directly to clients with these headers enabled.
+
+- **`X-MCP-Access`** (security boundary) — per-request write grant. With `ACCESS_ENFORCEMENT=on`, a write tool call is denied unless the request carries this header with value `write` (default-deny, checked on every request).
+- **`X-MCP-Toolsets`** (UX, not security) — comma-separated toolset names (`atf`, `catalog`, `diagnostics`, `records`, `scripts`, `update-sets`), read once from the session-creating request. Only the named toolsets' tools are registered for that session, trimming the tool list the model sees. Unknown names are ignored with a warning; if the header resolves to no known toolset, all toolsets register (fail-open). This filter never denies anything — write protection is `X-MCP-Access`'s job.
 
 ---
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -78,4 +78,5 @@ export const config = {
   accessEnforcement: rawEnforcement as 'on' | 'off',
   // Node lowercases incoming header names; keep the lookup key consistent.
   accessHeader: optional('ACCESS_HEADER', 'x-mcp-access').toLowerCase(),
+  toolsetsHeader: optional('TOOLSETS_HEADER', 'x-mcp-toolsets').toLowerCase(),
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,9 @@ import { buildServer } from './server.js';
 import { sessionStore } from './session-store.js';
 import {
   deriveEnforcement,
+  parseAllowedToolsets,
   type ToolRegistryOptions,
+  type Toolset,
 } from './tools/registry.js';
 
 function buildSnConfig(): ServiceNowConfig {
@@ -75,6 +77,18 @@ const registryOptions: ToolRegistryOptions = {
   ),
   accessHeader: config.accessHeader,
 };
+
+/**
+ * Toolset scoping is read once from the session-creating request and is
+ * constant for the session's life. Gateway mode only — env/stdio clients
+ * are direct users, not a trusted proxy, and always get the full surface.
+ */
+function resolveAllowedToolsets(
+  req: IncomingMessage,
+): Set<Toolset> | undefined {
+  if (config.credentialProvider !== 'header') return undefined;
+  return parseAllowedToolsets(req.headers[config.toolsetsHeader]);
+}
 
 async function resolveCredentials(
   req: IncomingMessage,
@@ -161,6 +175,13 @@ async function handleMcpRequest(
     credentialMs: Date.now() - credStart,
   });
 
+  const allowedToolsets = resolveAllowedToolsets(req);
+  if (allowedToolsets) {
+    log('INFO', 'Session tool surface scoped by toolsets header', {
+      toolsets: [...allowedToolsets],
+    });
+  }
+
   let resolvedSessionId: string | null = null;
 
   const transport = new StreamableHTTPServerTransport({
@@ -181,10 +202,10 @@ async function handleMcpRequest(
     },
   });
 
-  const { server } = buildServer(
-    new ServiceNowClient(credentials),
-    registryOptions,
-  );
+  const { server } = buildServer(new ServiceNowClient(credentials), {
+    ...registryOptions,
+    allowedToolsets,
+  });
 
   transport.onclose = () => {
     if (resolvedSessionId) {

--- a/src/tools/atf/atf.ts
+++ b/src/tools/atf/atf.ts
@@ -6,7 +6,7 @@ import {
   resolveDisplay,
   resolveValue,
 } from '../helpers.js';
-import type { ToolRegistry } from '../registry.js';
+import type { ToolRegistrar } from '../registry.js';
 import {
   AtfAddStep,
   AtfAddTestToSuite,
@@ -598,7 +598,7 @@ function formatInputStatus(
 }
 
 export function registerAtfTools(
-  registry: ToolRegistry,
+  registry: ToolRegistrar,
   client: ServiceNowClient,
 ): void {
   // ── Read: list step configs ──────────────────────────────────────────────

--- a/src/tools/atf/index.ts
+++ b/src/tools/atf/index.ts
@@ -1,1 +1,10 @@
-export { registerAtfTools } from './atf.js';
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import type { ToolRegistry } from '../registry.js';
+import { registerAtfTools as registerTools } from './atf.js';
+
+export function registerAtfTools(
+  registry: ToolRegistry,
+  client: ServiceNowClient,
+): void {
+  registerTools(registry.scoped('atf'), client);
+}

--- a/src/tools/catalog/client-scripts.ts
+++ b/src/tools/catalog/client-scripts.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import type { ServiceNowClient } from '../../clients/servicenow.js';
 import type { SnReference } from '../../types/servicenow.js';
 import { handleError, isSysId, resolveValue } from '../helpers.js';
-import type { ToolRegistry } from '../registry.js';
+import type { ToolRegistrar } from '../registry.js';
 import {
   CatalogClientScriptCreate,
   CatalogClientScriptUpdate,
@@ -15,7 +15,7 @@ const UI_TYPE_MAP: Record<string, string> = {
 };
 
 export function registerCatalogClientScriptTools(
-  registry: ToolRegistry,
+  registry: ToolRegistrar,
   client: ServiceNowClient,
 ): void {
   registry.registerTool(

--- a/src/tools/catalog/index.ts
+++ b/src/tools/catalog/index.ts
@@ -10,9 +10,10 @@ export function registerCatalogTools(
   registry: ToolRegistry,
   client: ServiceNowClient,
 ): void {
-  registerCatalogReadTools(registry, client);
-  registerCatalogWriteTools(registry, client);
-  registerRecordProducerTools(registry, client);
-  registerUiPolicyTools(registry, client);
-  registerCatalogClientScriptTools(registry, client);
+  const catalog = registry.scoped('catalog');
+  registerCatalogReadTools(catalog, client);
+  registerCatalogWriteTools(catalog, client);
+  registerRecordProducerTools(catalog, client);
+  registerUiPolicyTools(catalog, client);
+  registerCatalogClientScriptTools(catalog, client);
 }

--- a/src/tools/catalog/read.ts
+++ b/src/tools/catalog/read.ts
@@ -24,7 +24,7 @@ import {
   resolveDisplay,
   resolveValue,
 } from '../helpers.js';
-import type { ToolRegistry } from '../registry.js';
+import type { ToolRegistrar } from '../registry.js';
 
 function normaliseVariable(raw: RawVariable): CatalogVariable {
   // raw.type is { value: "8", display_value: "Reference" } with sysparm_display_value=all;
@@ -379,7 +379,7 @@ function buildSummary(def: CatalogItemDefinition): string {
 }
 
 export function registerCatalogReadTools(
-  registry: ToolRegistry,
+  registry: ToolRegistrar,
   client: ServiceNowClient,
 ): void {
   registry.registerTool(

--- a/src/tools/catalog/record-producers.ts
+++ b/src/tools/catalog/record-producers.ts
@@ -1,11 +1,11 @@
 import type { ServiceNowClient } from '../../clients/servicenow.js';
 import type { SnReference } from '../../types/servicenow.js';
 import { handleError, isSysId, resolveValue } from '../helpers.js';
-import type { ToolRegistry } from '../registry.js';
+import type { ToolRegistrar } from '../registry.js';
 import { RecordProducerCreate, RecordProducerUpdate } from './schemas.js';
 
 export function registerRecordProducerTools(
-  registry: ToolRegistry,
+  registry: ToolRegistrar,
   client: ServiceNowClient,
 ): void {
   registry.registerTool(

--- a/src/tools/catalog/translations.ts
+++ b/src/tools/catalog/translations.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { type ServiceNowClient, SnApiError } from '../../clients/servicenow.js';
 import type { SnReference } from '../../types/servicenow.js';
 import { handleError, isSysId, resolveValue } from '../helpers.js';
-import type { ToolRegistry } from '../registry.js';
+import type { ToolRegistrar } from '../registry.js';
 
 export const TRANSLATION_CONFIG = {
   enabled: false,
@@ -151,7 +151,7 @@ async function upsertTranslation(
 }
 
 export function registerCatalogTranslationTools(
-  registry: ToolRegistry,
+  registry: ToolRegistrar,
   client: ServiceNowClient,
 ): void {
   registry.registerTool(

--- a/src/tools/catalog/ui-policies.ts
+++ b/src/tools/catalog/ui-policies.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import type { ServiceNowClient } from '../../clients/servicenow.js';
 import type { SnReference } from '../../types/servicenow.js';
 import { handleError, isSysId, resolveValue } from '../helpers.js';
-import type { ToolRegistry } from '../registry.js';
+import type { ToolRegistrar } from '../registry.js';
 import {
   UiPolicyActionCreate,
   UiPolicyActionUpdate,
@@ -11,7 +11,7 @@ import {
 } from './schemas.js';
 
 export function registerUiPolicyTools(
-  registry: ToolRegistry,
+  registry: ToolRegistrar,
   client: ServiceNowClient,
 ): void {
   registry.registerTool(

--- a/src/tools/catalog/write.ts
+++ b/src/tools/catalog/write.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import type { ServiceNowClient } from '../../clients/servicenow.js';
 import { type SnReference, VARIABLE_TYPE_MAP } from '../../types/servicenow.js';
 import { handleError, isSysId, resolveValue } from '../helpers.js';
-import type { ToolRegistry } from '../registry.js';
+import type { ToolRegistrar } from '../registry.js';
 import {
   CatalogItemCreate,
   CatalogItemUpdate,
@@ -12,7 +12,7 @@ import {
 } from './schemas.js';
 
 export function registerCatalogWriteTools(
-  registry: ToolRegistry,
+  registry: ToolRegistrar,
   client: ServiceNowClient,
 ): void {
   registry.registerTool(

--- a/src/tools/diagnostics/background-scripts.ts
+++ b/src/tools/diagnostics/background-scripts.ts
@@ -1,10 +1,10 @@
 import type { ServiceNowClient } from '../../clients/servicenow.js';
 import { handleError } from '../helpers.js';
-import type { ToolRegistry } from '../registry.js';
+import type { ToolRegistrar } from '../registry.js';
 import { BackgroundScriptExecute } from './schemas.js';
 
 export function registerBackgroundScriptTools(
-  registry: ToolRegistry,
+  registry: ToolRegistrar,
   client: ServiceNowClient,
 ): void {
   registry.registerTool(

--- a/src/tools/diagnostics/fix-scripts.ts
+++ b/src/tools/diagnostics/fix-scripts.ts
@@ -1,11 +1,11 @@
 import type { ServiceNowClient } from '../../clients/servicenow.js';
 import type { SnReference } from '../../types/servicenow.js';
 import { handleError, isSysId, resolveValue } from '../helpers.js';
-import type { ToolRegistry } from '../registry.js';
+import type { ToolRegistrar } from '../registry.js';
 import { FixScriptCreate, FixScriptRun, FixScriptUpdate } from './schemas.js';
 
 export function registerFixScriptTools(
-  registry: ToolRegistry,
+  registry: ToolRegistrar,
   client: ServiceNowClient,
 ): void {
   registry.registerTool(

--- a/src/tools/diagnostics/index.ts
+++ b/src/tools/diagnostics/index.ts
@@ -7,6 +7,7 @@ export function registerDiagnosticsTools(
   registry: ToolRegistry,
   client: ServiceNowClient,
 ): void {
-  registerBackgroundScriptTools(registry, client);
-  registerFixScriptTools(registry, client);
+  const diagnostics = registry.scoped('diagnostics');
+  registerBackgroundScriptTools(diagnostics, client);
+  registerFixScriptTools(diagnostics, client);
 }

--- a/src/tools/records/index.ts
+++ b/src/tools/records/index.ts
@@ -6,5 +6,5 @@ export function registerRecordTools(
   registry: ToolRegistry,
   client: ServiceNowClient,
 ): void {
-  registerTableCrudTools(registry, client);
+  registerTableCrudTools(registry.scoped('records'), client);
 }

--- a/src/tools/records/table-crud.ts
+++ b/src/tools/records/table-crud.ts
@@ -2,10 +2,10 @@ import { z } from 'zod';
 import type { ServiceNowClient } from '../../clients/servicenow.js';
 import type { SnReference } from '../../types/servicenow.js';
 import { handleError } from '../helpers.js';
-import type { ToolRegistry } from '../registry.js';
+import type { ToolRegistrar } from '../registry.js';
 
 export function registerTableCrudTools(
-  registry: ToolRegistry,
+  registry: ToolRegistrar,
   client: ServiceNowClient,
 ): void {
   registry.registerTool(

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -11,73 +11,229 @@ import { buildServer } from '../server.js';
 import { buildTestPair, firstText } from '../tests/helpers.js';
 import {
   deriveEnforcement,
+  parseAllowedToolsets,
   type ToolAccess,
   ToolRegistry,
   type ToolRegistryOptions,
 } from './registry.js';
 
-describe('tool access classification', () => {
-  it('classifies every registered tool as read or write', () => {
+describe('tool inventory', () => {
+  it('classifies every registered tool with access and toolset group', () => {
     // Registration never calls ServiceNow — the client is only captured in
     // handler closures — so an empty stub is enough to build the server.
+    // No allowed-set → all toolsets register, so this is the full inventory.
     const { registry } = buildServer({} as ServiceNowClient);
 
-    // Security-relevant: a tool classified 'read' here will be callable
-    // without write access once per-request enforcement lands. Any change
-    // to this snapshot must be reviewed with that in mind.
-    expect(registry.accessMap()).toMatchInlineSnapshot(`
+    // Security-relevant: a tool classified 'read' here is callable without
+    // write access under per-request enforcement. Any change to this
+    // snapshot must be reviewed with that in mind. (Groups are UX scoping
+    // only.)
+    expect(registry.inventory()).toMatchInlineSnapshot(`
       {
-        "add_atf_step": "write",
-        "add_atf_test_to_suite": "write",
-        "associate_variable_set": "write",
-        "attach_user_criteria": "write",
-        "batch_create_catalog_client_scripts": "write",
-        "batch_create_catalog_variables": "write",
-        "batch_create_ui_policies": "write",
-        "batch_create_ui_policy_actions": "write",
-        "batch_update_catalog_variables": "write",
-        "create_atf_test": "write",
-        "create_atf_test_suite": "write",
-        "create_business_rule": "write",
-        "create_catalog_item": "write",
-        "create_fix_script": "write",
-        "create_record": "write",
-        "create_record_producer": "write",
-        "create_script_include": "write",
-        "create_update_set": "write",
-        "execute_background_script": "write",
-        "find_reusable_variables": "read",
-        "find_user_criteria": "read",
-        "get_atf_step_config_schema": "read",
-        "get_atf_test": "read",
-        "get_catalog_item_definition": "read",
-        "get_current_update_set": "read",
-        "get_record": "read",
-        "list_atf_step_configs": "read",
-        "list_atf_tests": "read",
-        "list_catalog_categories": "read",
-        "list_catalog_items": "read",
-        "list_catalogs": "read",
-        "list_flows": "read",
-        "list_update_sets": "read",
-        "list_variable_set_variables": "read",
-        "list_workflows": "read",
-        "query_records": "read",
-        "resolve_table": "read",
-        "run_fix_script": "write",
-        "set_current_update_set": "write",
-        "update_atf_step": "write",
-        "update_atf_test": "write",
-        "update_atf_test_suite": "write",
-        "update_business_rule": "write",
-        "update_catalog_client_script": "write",
-        "update_catalog_item": "write",
-        "update_fix_script": "write",
-        "update_record": "write",
-        "update_record_producer": "write",
-        "update_script_include": "write",
-        "update_ui_policy": "write",
-        "update_ui_policy_action": "write",
+        "add_atf_step": {
+          "access": "write",
+          "group": "atf",
+        },
+        "add_atf_test_to_suite": {
+          "access": "write",
+          "group": "atf",
+        },
+        "associate_variable_set": {
+          "access": "write",
+          "group": "catalog",
+        },
+        "attach_user_criteria": {
+          "access": "write",
+          "group": "catalog",
+        },
+        "batch_create_catalog_client_scripts": {
+          "access": "write",
+          "group": "catalog",
+        },
+        "batch_create_catalog_variables": {
+          "access": "write",
+          "group": "catalog",
+        },
+        "batch_create_ui_policies": {
+          "access": "write",
+          "group": "catalog",
+        },
+        "batch_create_ui_policy_actions": {
+          "access": "write",
+          "group": "catalog",
+        },
+        "batch_update_catalog_variables": {
+          "access": "write",
+          "group": "catalog",
+        },
+        "create_atf_test": {
+          "access": "write",
+          "group": "atf",
+        },
+        "create_atf_test_suite": {
+          "access": "write",
+          "group": "atf",
+        },
+        "create_business_rule": {
+          "access": "write",
+          "group": "scripts",
+        },
+        "create_catalog_item": {
+          "access": "write",
+          "group": "catalog",
+        },
+        "create_fix_script": {
+          "access": "write",
+          "group": "diagnostics",
+        },
+        "create_record": {
+          "access": "write",
+          "group": "records",
+        },
+        "create_record_producer": {
+          "access": "write",
+          "group": "catalog",
+        },
+        "create_script_include": {
+          "access": "write",
+          "group": "scripts",
+        },
+        "create_update_set": {
+          "access": "write",
+          "group": "update-sets",
+        },
+        "execute_background_script": {
+          "access": "write",
+          "group": "diagnostics",
+        },
+        "find_reusable_variables": {
+          "access": "read",
+          "group": "catalog",
+        },
+        "find_user_criteria": {
+          "access": "read",
+          "group": "catalog",
+        },
+        "get_atf_step_config_schema": {
+          "access": "read",
+          "group": "atf",
+        },
+        "get_atf_test": {
+          "access": "read",
+          "group": "atf",
+        },
+        "get_catalog_item_definition": {
+          "access": "read",
+          "group": "catalog",
+        },
+        "get_current_update_set": {
+          "access": "read",
+          "group": "update-sets",
+        },
+        "get_record": {
+          "access": "read",
+          "group": "records",
+        },
+        "list_atf_step_configs": {
+          "access": "read",
+          "group": "atf",
+        },
+        "list_atf_tests": {
+          "access": "read",
+          "group": "atf",
+        },
+        "list_catalog_categories": {
+          "access": "read",
+          "group": "catalog",
+        },
+        "list_catalog_items": {
+          "access": "read",
+          "group": "catalog",
+        },
+        "list_catalogs": {
+          "access": "read",
+          "group": "catalog",
+        },
+        "list_flows": {
+          "access": "read",
+          "group": "catalog",
+        },
+        "list_update_sets": {
+          "access": "read",
+          "group": "update-sets",
+        },
+        "list_variable_set_variables": {
+          "access": "read",
+          "group": "catalog",
+        },
+        "list_workflows": {
+          "access": "read",
+          "group": "catalog",
+        },
+        "query_records": {
+          "access": "read",
+          "group": "records",
+        },
+        "resolve_table": {
+          "access": "read",
+          "group": "catalog",
+        },
+        "run_fix_script": {
+          "access": "write",
+          "group": "diagnostics",
+        },
+        "set_current_update_set": {
+          "access": "write",
+          "group": "update-sets",
+        },
+        "update_atf_step": {
+          "access": "write",
+          "group": "atf",
+        },
+        "update_atf_test": {
+          "access": "write",
+          "group": "atf",
+        },
+        "update_atf_test_suite": {
+          "access": "write",
+          "group": "atf",
+        },
+        "update_business_rule": {
+          "access": "write",
+          "group": "scripts",
+        },
+        "update_catalog_client_script": {
+          "access": "write",
+          "group": "catalog",
+        },
+        "update_catalog_item": {
+          "access": "write",
+          "group": "catalog",
+        },
+        "update_fix_script": {
+          "access": "write",
+          "group": "diagnostics",
+        },
+        "update_record": {
+          "access": "write",
+          "group": "records",
+        },
+        "update_record_producer": {
+          "access": "write",
+          "group": "catalog",
+        },
+        "update_script_include": {
+          "access": "write",
+          "group": "scripts",
+        },
+        "update_ui_policy": {
+          "access": "write",
+          "group": "catalog",
+        },
+        "update_ui_policy_action": {
+          "access": "write",
+          "group": "catalog",
+        },
       }
     `);
   });
@@ -134,6 +290,108 @@ describe('ToolRegistry', () => {
     expect(firstText(result)).toBe('hello');
 
     await teardown();
+  });
+});
+
+describe('toolset scoping', () => {
+  function stubServer(registered: string[]): McpServer {
+    return {
+      registerTool: (name: string) => {
+        registered.push(name);
+        return {} as RegisteredTool;
+      },
+    } as unknown as McpServer;
+  }
+
+  const noop = async () => ({
+    content: [{ type: 'text' as const, text: 'ok' }],
+  });
+
+  it('scoped view stamps its toolset on every tool it registers', () => {
+    const registry = new ToolRegistry(stubServer([]), { enforcement: 'off' });
+    registry.scoped('catalog').registerTool('a', { access: 'read' }, noop);
+    registry.scoped('records').registerTool('b', { access: 'write' }, noop);
+
+    expect(registry.inventory()).toEqual({
+      a: { access: 'read', group: 'catalog' },
+      b: { access: 'write', group: 'records' },
+    });
+  });
+
+  it('skips registration for toolsets outside the allowed-set', () => {
+    const registered: string[] = [];
+    const registry = new ToolRegistry(stubServer(registered), {
+      enforcement: 'off',
+      allowedToolsets: new Set(['records']),
+    });
+    registry.scoped('catalog').registerTool('a', { access: 'read' }, noop);
+    registry.scoped('records').registerTool('b', { access: 'write' }, noop);
+
+    expect(registered).toEqual(['b']);
+    expect(registry.inventory()).toEqual({
+      b: { access: 'write', group: 'records' },
+    });
+  });
+
+  it('no allowed-set means every toolset registers', () => {
+    const registered: string[] = [];
+    const registry = new ToolRegistry(stubServer(registered), {
+      enforcement: 'off',
+    });
+    registry.scoped('atf').registerTool('a', { access: 'read' }, noop);
+    registry.scoped('update-sets').registerTool('b', { access: 'read' }, noop);
+
+    expect(registered).toEqual(['a', 'b']);
+  });
+
+  it('buildServer with an allowed-set exposes exactly that subset of the full inventory', async () => {
+    const full = buildServer({} as ServiceNowClient).registry.inventory();
+    const expected = Object.keys(full).filter(
+      (name) => full[name].group === 'records',
+    );
+    expect(expected.length).toBeGreaterThan(0);
+
+    const { server } = buildServer({} as ServiceNowClient, {
+      enforcement: 'off',
+      allowedToolsets: new Set(['records']),
+    });
+    const [serverTransport, clientTransport] =
+      InMemoryTransport.createLinkedPair();
+    const mcpClient = new Client({ name: 'test-client', version: '1.0.0' });
+    await server.connect(serverTransport);
+    await mcpClient.connect(clientTransport);
+
+    const { tools } = await mcpClient.listTools();
+    expect(tools.map((t) => t.name).sort()).toEqual(expected.sort());
+    await mcpClient.close();
+  });
+});
+
+describe('parseAllowedToolsets', () => {
+  it('absent header → undefined (all toolsets)', () => {
+    expect(parseAllowedToolsets(undefined)).toBeUndefined();
+  });
+
+  it('valid subset, trimmed and case-insensitive', () => {
+    expect(parseAllowedToolsets(' Catalog , SCRIPTS ')).toEqual(
+      new Set(['catalog', 'scripts']),
+    );
+  });
+
+  it('unknown names are dropped, known ones kept', () => {
+    expect(parseAllowedToolsets('catalog,bogus')).toEqual(new Set(['catalog']));
+  });
+
+  it('fail-open: empty or all-unknown header → undefined (all toolsets)', () => {
+    expect(parseAllowedToolsets('')).toBeUndefined();
+    expect(parseAllowedToolsets(' , ')).toBeUndefined();
+    expect(parseAllowedToolsets('bogus,nope')).toBeUndefined();
+  });
+
+  it('joins repeated headers (string array) before parsing', () => {
+    expect(parseAllowedToolsets(['catalog', 'records,atf'])).toEqual(
+      new Set(['catalog', 'records', 'atf']),
+    );
   });
 });
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -29,10 +29,68 @@ export type ToolAccess = 'read' | 'write';
  */
 export type AccessEnforcementMode = 'enforce' | 'observe' | 'off';
 
+/** A toolset is exactly a domain folder under src/tools/. */
+export const TOOLSETS = [
+  'atf',
+  'catalog',
+  'diagnostics',
+  'records',
+  'scripts',
+  'update-sets',
+] as const;
+
+export type Toolset = (typeof TOOLSETS)[number];
+
+function isToolset(value: string): value is Toolset {
+  return (TOOLSETS as readonly string[]).includes(value);
+}
+
+/**
+ * Parses the toolsets header (comma-separated names) into the registry's
+ * allowed-set. Fail-open: an absent header, unknown names, or an empty
+ * result fall back to the full surface (`undefined` = all toolsets) — this
+ * filter trims the tool surface, it never denies.
+ */
+export function parseAllowedToolsets(
+  raw: string | string[] | undefined,
+): Set<Toolset> | undefined {
+  if (raw === undefined) return undefined;
+
+  const names = (Array.isArray(raw) ? raw.join(',') : raw)
+    .split(',')
+    .map((name) => name.trim().toLowerCase())
+    .filter((name) => name.length > 0);
+
+  const unknown = names.filter((name) => !isToolset(name));
+  if (unknown.length > 0) {
+    log('WARN', 'Ignoring unknown toolset names in toolsets header', {
+      unknown,
+      known: [...TOOLSETS],
+    });
+  }
+
+  const allowed = new Set(names.filter(isToolset));
+  if (allowed.size === 0) {
+    log(
+      'WARN',
+      'Toolsets header present but resolved to no known toolset — registering all toolsets (fail-open)',
+      { header: raw },
+    );
+    return undefined;
+  }
+  return allowed;
+}
+
 export type ToolRegistryOptions = {
   enforcement: AccessEnforcementMode;
   /** Lowercase header name carrying the access value. */
   accessHeader?: string;
+  /**
+   * Toolsets allowed to register; absent → all. Must be constant for the
+   * server's lifetime. UX scoping only — the security boundary is the
+   * per-request access check in wrapHandler.
+   */
+  allowedToolsets?: ReadonlySet<Toolset>;
 };
 
 /**
@@ -76,16 +134,37 @@ type ToolConfig<
 };
 
 /**
+ * Registration surface handed to tool files — obtained via
+ * ToolRegistry.scoped(), so tool files never name their own toolset.
+ */
+export interface ToolRegistrar {
+  registerTool<
+    OutputArgs extends ZodRawShapeCompat | AnySchema,
+    InputArgs extends undefined | ZodRawShapeCompat | AnySchema = undefined,
+  >(
+    name: string,
+    config: ToolConfig<OutputArgs, InputArgs>,
+    cb: ToolCallback<InputArgs>,
+  ): void;
+}
+
+export type ToolInventoryEntry = {
+  access: ToolAccess;
+  group: Toolset | undefined;
+};
+
+/**
  * The only path to McpServer.registerTool. Requires every tool to declare
  * `access` at its registration site and derives the MCP `readOnlyHint`
  * annotation from it (the classification is authoritative — a conflicting
  * caller-supplied readOnlyHint is overridden; all other annotations are
  * preserved).
  */
-export class ToolRegistry {
-  private readonly access = new Map<string, ToolAccess>();
+export class ToolRegistry implements ToolRegistrar {
+  private readonly tools = new Map<string, ToolInventoryEntry>();
   private readonly enforcement: AccessEnforcementMode;
   private readonly accessHeader: string;
+  private readonly allowedToolsets?: ReadonlySet<Toolset>;
 
   constructor(
     private readonly server: McpServer,
@@ -93,6 +172,7 @@ export class ToolRegistry {
   ) {
     this.enforcement = options.enforcement;
     this.accessHeader = options.accessHeader ?? DEFAULT_ACCESS_HEADER;
+    this.allowedToolsets = options.allowedToolsets;
   }
 
   registerTool<
@@ -103,8 +183,43 @@ export class ToolRegistry {
     config: ToolConfig<OutputArgs, InputArgs>,
     cb: ToolCallback<InputArgs>,
   ): RegisteredTool {
+    return this.register(name, config, cb, undefined);
+  }
+
+  /**
+   * Returns a view that stamps `toolset` on every tool registered through
+   * it, and silently skips registration when the allowed-set excludes the
+   * toolset. Called once per domain, in the domain's index.ts.
+   */
+  scoped(toolset: Toolset): ToolRegistrar {
+    return {
+      registerTool: <
+        OutputArgs extends ZodRawShapeCompat | AnySchema,
+        InputArgs extends undefined | ZodRawShapeCompat | AnySchema = undefined,
+      >(
+        name: string,
+        config: ToolConfig<OutputArgs, InputArgs>,
+        cb: ToolCallback<InputArgs>,
+      ): void => {
+        if (this.allowedToolsets && !this.allowedToolsets.has(toolset)) {
+          return;
+        }
+        this.register(name, config, cb, toolset);
+      },
+    };
+  }
+
+  private register<
+    OutputArgs extends ZodRawShapeCompat | AnySchema,
+    InputArgs extends undefined | ZodRawShapeCompat | AnySchema = undefined,
+  >(
+    name: string,
+    config: ToolConfig<OutputArgs, InputArgs>,
+    cb: ToolCallback<InputArgs>,
+    group: Toolset | undefined,
+  ): RegisteredTool {
     const { access, annotations, ...rest } = config;
-    this.access.set(name, access);
+    this.tools.set(name, { access, group });
 
     return this.server.registerTool<OutputArgs, InputArgs>(
       name,
@@ -171,10 +286,10 @@ export class ToolRegistry {
       : 'read';
   }
 
-  /** Tool name → access classification, sorted by name. */
-  accessMap(): Record<string, ToolAccess> {
+  /** Tool name → { access, group }, sorted by name. */
+  inventory(): Record<string, ToolInventoryEntry> {
     return Object.fromEntries(
-      [...this.access.entries()].sort(([a], [b]) => a.localeCompare(b)),
+      [...this.tools.entries()].sort(([a], [b]) => a.localeCompare(b)),
     );
   }
 }

--- a/src/tools/scripts/business-rules.ts
+++ b/src/tools/scripts/business-rules.ts
@@ -1,11 +1,11 @@
 import type { ServiceNowClient } from '../../clients/servicenow.js';
 import type { SnReference } from '../../types/servicenow.js';
 import { handleError, isSysId } from '../helpers.js';
-import type { ToolRegistry } from '../registry.js';
+import type { ToolRegistrar } from '../registry.js';
 import { BusinessRuleCreate, BusinessRuleUpdate } from './schemas.js';
 
 export function registerBusinessRuleTools(
-  registry: ToolRegistry,
+  registry: ToolRegistrar,
   client: ServiceNowClient,
 ): void {
   registry.registerTool(

--- a/src/tools/scripts/index.ts
+++ b/src/tools/scripts/index.ts
@@ -7,6 +7,7 @@ export function registerScriptTools(
   registry: ToolRegistry,
   client: ServiceNowClient,
 ): void {
-  registerScriptIncludeTools(registry, client);
-  registerBusinessRuleTools(registry, client);
+  const scripts = registry.scoped('scripts');
+  registerScriptIncludeTools(scripts, client);
+  registerBusinessRuleTools(scripts, client);
 }

--- a/src/tools/scripts/script-includes.ts
+++ b/src/tools/scripts/script-includes.ts
@@ -1,11 +1,11 @@
 import type { ServiceNowClient } from '../../clients/servicenow.js';
 import type { SnReference } from '../../types/servicenow.js';
 import { handleError, isSysId, resolveValue } from '../helpers.js';
-import type { ToolRegistry } from '../registry.js';
+import type { ToolRegistrar } from '../registry.js';
 import { ScriptIncludeCreate, ScriptIncludeUpdate } from './schemas.js';
 
 export function registerScriptIncludeTools(
-  registry: ToolRegistry,
+  registry: ToolRegistrar,
   client: ServiceNowClient,
 ): void {
   registry.registerTool(

--- a/src/tools/update-sets/index.ts
+++ b/src/tools/update-sets/index.ts
@@ -1,1 +1,10 @@
-export { registerUpdateSetTools } from './update-sets.js';
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import type { ToolRegistry } from '../registry.js';
+import { registerUpdateSetTools as registerTools } from './update-sets.js';
+
+export function registerUpdateSetTools(
+  registry: ToolRegistry,
+  client: ServiceNowClient,
+): void {
+  registerTools(registry.scoped('update-sets'), client);
+}

--- a/src/tools/update-sets/update-sets.ts
+++ b/src/tools/update-sets/update-sets.ts
@@ -11,7 +11,7 @@ import {
   resolveDisplay,
   resolveValue,
 } from '../helpers.js';
-import type { ToolRegistry } from '../registry.js';
+import type { ToolRegistrar } from '../registry.js';
 import {
   SetCurrentUpdateSet,
   UpdateSetCreate,
@@ -150,7 +150,7 @@ async function alsoSetForUiUser(
 }
 
 export function registerUpdateSetTools(
-  registry: ToolRegistry,
+  registry: ToolRegistrar,
   client: ServiceNowClient,
 ): void {
   registry.registerTool(


### PR DESCRIPTION
## What this changes

Lets a trusted proxy restrict which tool domains a session sees by sending an `X-MCP-Toolsets` header (comma-separated; name configurable via `TOOLSETS_HEADER`) on the session-creating request. A toolset is exactly a domain folder under `src/tools/`: `atf`, `catalog`, `diagnostics`, `records`, `scripts`, `update-sets`.

This is a **UX feature, not a security boundary** — the existing per-request access enforcement (`registry.wrapHandler`) stays the security gate and is untouched. Accordingly the filter is fail-open: no header, env/stdio mode, unknown names, or an empty result all register the full surface (unknown names and empty results log WARN).

Mechanics:
- `ToolRegistry.scoped(toolset)` returns a `ToolRegistrar` view that stamps its toolset on every tool registered through it, and silently skips registration when the registry's `allowedToolsets` excludes it. Each domain's `index.ts` names its toolset exactly once; individual tool files never do.
- Registration-time filtering is safe here (unlike access enforcement) because the toolset set is read once from the session-creating request and is constant for the session's life.
- The snapshot inventory is extended from `{tool → access}` to `{tool → {access, group}}`, generated from registration.

## How it was verified

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test` passing (276 tests, incl. new scoping/parsing suites; with no header the tool surface is unchanged — full inventory snapshot)
- [x] Exercised e2e against the HTTP server in gateway mode with curl: `records` header → 4 tools; no header → all 51; `bogus,nope` → all 51 with fail-open WARNs; `atf, UPDATE-SETS` → 15 tools (case/whitespace normalized)

## Notes

- New `ToolRegistrar` interface is the minimal registration surface handed to tool files (they previously took the full `ToolRegistry`); `ToolRegistry` implements it, so test helpers are unchanged.
- `atf` and `update-sets` previously re-exported their register function directly; they now have real `index.ts` wrappers to name their toolset, per the one-entry-point-per-domain invariant.
- Pre-existing, unchanged: `catalog/translations.ts` exports `registerCatalogTranslationTools` but is never wired into `catalog/index.ts`, so those tools don't register today. Flagged for a follow-up rather than silently changing the live tool surface here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)