### PR TITLE
feat: add client script tools for creation and update functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Built and maintained by **Veldev** — an AI assistant for ServiceNow developers
 
 ## Features
 
-60 tools across 13 domains:
+62 tools across 13 domains:
 
 | Domain | What it covers |
 |---|---|
@@ -19,9 +19,10 @@ Built and maintained by **Veldev** — an AI assistant for ServiceNow developers
 | **Catalog (write)** | Create items, add/update variables, manage variable sets, attach user criteria |
 | **Record producers** | Create and update record producers (catalog forms that generate records in any table) |
 | **UI policies** | Create and update catalog UI policies and their actions |
-| **Client scripts** | Create and manage catalog client scripts |
+| **Client scripts (catalog)** | Create and manage catalog client scripts |
 | **Script includes** | Create reusable server-side script includes |
 | **Business rules** | Create business rules with before/after/async modes |
+| **Client scripts (form)** | Create and update table client scripts (`sys_script_client`) — onLoad / onChange / onSubmit / onCellEdit |
 | **Update sets** | Show the active update set, list update sets by state/scope/name, create a new set, and switch the current set for the authenticated user |
 | **Background scripts** | Schedule server-side JavaScript snippets via `sys_trigger` |
 | **Fix scripts** | Create, update, and run `sys_script_fix` records — stored server-side scripts for data and config repairs |
@@ -214,6 +215,8 @@ What client scripts are on the New Employee Onboarding item?
 Create a new catalog item called "VPN Access Request" with a text variable for business justification
 
 Create a business rule on incident that sets priority to 1 when impact and urgency are both 1
+
+Create an onLoad client script on incident that shows an info message when the priority is 1 - Critical
 
 Create a record producer called "New Hire Equipment" that generates an sc_req_item record, with a pre-insert script that maps the selected laptop model to the item field
 

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -82,6 +82,10 @@ describe('tool inventory', () => {
           "access": "write",
           "group": "catalog",
         },
+        "create_client_script": {
+          "access": "write",
+          "group": "scripts",
+        },
         "create_fix_script": {
           "access": "write",
           "group": "diagnostics",
@@ -233,6 +237,10 @@ describe('tool inventory', () => {
         "update_catalog_item": {
           "access": "write",
           "group": "catalog",
+        },
+        "update_client_script": {
+          "access": "write",
+          "group": "scripts",
         },
         "update_fix_script": {
           "access": "write",

--- a/src/tools/scripts/client-scripts.test.ts
+++ b/src/tools/scripts/client-scripts.test.ts
@@ -1,0 +1,295 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import { SnApiError } from '../../clients/servicenow.js';
+import { buildTestPair, firstText } from '../../tests/helpers.js';
+import { registerClientScriptTools } from './client-scripts.js';
+
+const EXISTING_SCRIPT_SYS_ID = 'aaaa1111bbbb2222aaaa1111bbbb2222';
+const NEW_SCRIPT_SYS_ID = 'dddd3333eeee4444dddd3333eeee4444';
+
+function buildMockClient(): ServiceNowClient {
+  return {
+    listRecords: vi.fn().mockResolvedValue([]),
+    createRecord: vi.fn().mockResolvedValue({
+      sys_id: { value: NEW_SCRIPT_SYS_ID, display_value: NEW_SCRIPT_SYS_ID },
+    }),
+    patchRecord: vi.fn().mockResolvedValue({}),
+  } as unknown as ServiceNowClient;
+}
+
+describe('client-script tools (in-memory MCP)', () => {
+  let mcpClient: Client;
+  let teardown: () => Promise<void>;
+
+  beforeEach(async () => {
+    const pair = await buildTestPair(
+      registerClientScriptTools,
+      buildMockClient(),
+    );
+    mcpClient = pair.mcpClient;
+    teardown = pair.teardown;
+  });
+
+  afterEach(async () => {
+    await teardown();
+  });
+
+  describe('create_client_script', () => {
+    it('creates the script and returns its sys_id', async () => {
+      const result = await mcpClient.callTool({
+        name: 'create_client_script',
+        arguments: {
+          name: 'Hide field on load',
+          table: 'incident',
+          type: 'onLoad',
+          script: 'function onLoad() { g_form.setDisplay("priority", false); }',
+        },
+      });
+      const text = firstText(result);
+      expect(text).toContain('created successfully');
+      expect(text).toContain(NEW_SCRIPT_SYS_ID);
+      expect(text).toContain('Hide field on load');
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('maps defaults and ui_type to serialised strings', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerClientScriptTools, mockClient);
+      try {
+        await pair.mcpClient.callTool({
+          name: 'create_client_script',
+          arguments: {
+            name: 'My Script',
+            table: 'change_request',
+            type: 'onLoad',
+            script: 'function onLoad() {}',
+          },
+        });
+        expect(mockClient.createRecord).toHaveBeenCalledWith(
+          'sys_script_client',
+          expect.objectContaining({
+            name: 'My Script',
+            table: 'change_request',
+            type: 'onLoad',
+            active: 'true',
+            ui_type: '10',
+            global: 'true',
+            applies_extended: 'false',
+            isolate_script: 'true',
+          }),
+        );
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('passes field through for onChange scripts', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerClientScriptTools, mockClient);
+      try {
+        await pair.mcpClient.callTool({
+          name: 'create_client_script',
+          arguments: {
+            name: 'React to category',
+            table: 'incident',
+            type: 'onChange',
+            field: 'category',
+            script:
+              'function onChange(control, oldValue, newValue, isLoading) {}',
+          },
+        });
+        expect(mockClient.createRecord).toHaveBeenCalledWith(
+          'sys_script_client',
+          expect.objectContaining({ type: 'onChange', field: 'category' }),
+        );
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('returns isError when onChange omits field', async () => {
+      const result = await mcpClient.callTool({
+        name: 'create_client_script',
+        arguments: {
+          name: 'No field',
+          table: 'incident',
+          type: 'onChange',
+          script: 'function onChange() {}',
+        },
+      });
+      expect(result.isError).toBe(true);
+      const text = firstText(result);
+      expect(text).toContain('field is required');
+    });
+
+    it('returns existing record without creating when name+table already exists', async () => {
+      const idempotentClient = {
+        ...buildMockClient(),
+        listRecords: vi.fn().mockResolvedValue([
+          {
+            sys_id: {
+              value: EXISTING_SCRIPT_SYS_ID,
+              display_value: EXISTING_SCRIPT_SYS_ID,
+            },
+          },
+        ]),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(
+        registerClientScriptTools,
+        idempotentClient,
+      );
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'create_client_script',
+          arguments: {
+            name: 'My Script',
+            table: 'incident',
+            type: 'onLoad',
+            script: 'function onLoad() {}',
+          },
+        });
+        const text = firstText(result);
+        expect(text).toContain('already exists');
+        expect(text).toContain(EXISTING_SCRIPT_SYS_ID);
+        expect(idempotentClient.createRecord).not.toHaveBeenCalled();
+        expect(result.isError).toBeFalsy();
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('surfaces SnApiError as isError with status in message', async () => {
+      const errorClient = {
+        ...buildMockClient(),
+        listRecords: vi
+          .fn()
+          .mockRejectedValue(
+            new SnApiError(
+              500,
+              'Internal Server Error',
+              'fault',
+              'https://example.com',
+            ),
+          ),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(registerClientScriptTools, errorClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'create_client_script',
+          arguments: {
+            name: 'My Script',
+            table: 'incident',
+            type: 'onLoad',
+            script: 'function onLoad() {}',
+          },
+        });
+        expect(result.isError).toBe(true);
+        const text = firstText(result);
+        expect(text).toContain('500');
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('rejects empty name with Zod validation error', async () => {
+      const result = await mcpClient.callTool({
+        name: 'create_client_script',
+        arguments: {
+          name: '',
+          table: 'incident',
+          type: 'onLoad',
+          script: 'function onLoad() {}',
+        },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('update_client_script', () => {
+    it('patches the record and lists updated fields', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_client_script',
+        arguments: {
+          sys_id: EXISTING_SCRIPT_SYS_ID,
+          name: 'Renamed Script',
+          active: false,
+        },
+      });
+      const text = firstText(result);
+      expect(text).toContain('updated successfully');
+      expect(text).toContain(EXISTING_SCRIPT_SYS_ID);
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('serialises ui_type and booleans correctly', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerClientScriptTools, mockClient);
+      try {
+        await pair.mcpClient.callTool({
+          name: 'update_client_script',
+          arguments: {
+            sys_id: EXISTING_SCRIPT_SYS_ID,
+            ui_type: 'mobile',
+            active: false,
+          },
+        });
+        expect(mockClient.patchRecord).toHaveBeenCalledWith(
+          'sys_script_client',
+          EXISTING_SCRIPT_SYS_ID,
+          expect.objectContaining({ ui_type: '1', active: 'false' }),
+        );
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('returns isError when sys_id is not a valid hex id', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_client_script',
+        arguments: { sys_id: 'not-a-valid-id', name: 'x' },
+      });
+      expect(result.isError).toBe(true);
+      const text = firstText(result);
+      expect(text).toContain('not a valid');
+    });
+
+    it('returns no-op message when no fields are provided besides sys_id', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_client_script',
+        arguments: { sys_id: EXISTING_SCRIPT_SYS_ID },
+      });
+      const text = firstText(result);
+      expect(text).toContain('No fields to update');
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('surfaces SnApiError as isError with status in message', async () => {
+      const errorClient = {
+        ...buildMockClient(),
+        patchRecord: vi
+          .fn()
+          .mockRejectedValue(
+            new SnApiError(
+              404,
+              'Not Found',
+              'no record',
+              'https://example.com',
+            ),
+          ),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(registerClientScriptTools, errorClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'update_client_script',
+          arguments: { sys_id: EXISTING_SCRIPT_SYS_ID, name: 'New Name' },
+        });
+        expect(result.isError).toBe(true);
+        const text = firstText(result);
+        expect(text).toContain('404');
+      } finally {
+        await pair.teardown();
+      }
+    });
+  });
+});

--- a/src/tools/scripts/client-scripts.ts
+++ b/src/tools/scripts/client-scripts.ts
@@ -1,0 +1,243 @@
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import type { SnReference } from '../../types/servicenow.js';
+import { handleError, isSysId, resolveValue } from '../helpers.js';
+import type { ToolRegistrar } from '../registry.js';
+import { ClientScriptCreate, ClientScriptUpdate } from './schemas.js';
+
+const UI_TYPE_MAP: Record<string, string> = {
+  desktop: '0',
+  mobile: '1',
+  all: '10',
+};
+
+// onChange and onCellEdit scripts target a specific field.
+const FIELD_REQUIRED_TYPES = new Set(['onChange', 'onCellEdit']);
+
+export function registerClientScriptTools(
+  registry: ToolRegistrar,
+  client: ServiceNowClient,
+): void {
+  registry.registerTool(
+    'create_client_script',
+    {
+      access: 'write',
+      title: 'Create Client Script',
+      description: [
+        'Creates a sys_script_client record (client script) on a ServiceNow table.',
+        '',
+        'WHEN TO USE: when form behavior must run in the browser — set defaults, toggle',
+        'mandatory/read-only/visible state, react to a field change, or validate on submit.',
+        'For server-side logic use create_business_rule. For catalog item forms use the',
+        'catalog client script tools instead.',
+        '',
+        "IMPORTANT: type='onChange' and type='onCellEdit' require field (the internal",
+        'name of the field to watch).',
+        'IMPORTANT: client scripts run BEFORE UI policies — avoid targeting the same field',
+        'with both unless you intend the UI policy to win.',
+        '',
+        'Idempotent: if a client script with the same name already exists on the same table,',
+        'the existing record is returned and no new record is created.',
+      ].join('\n'),
+      inputSchema: ClientScriptCreate,
+      annotations: {
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({
+      name,
+      table,
+      type,
+      field,
+      script,
+      active,
+      ui_type,
+      global,
+      view,
+      applies_extended,
+      isolate_script,
+      order,
+      description,
+      messages,
+    }) => {
+      try {
+        if (FIELD_REQUIRED_TYPES.has(type) && !field) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `field is required for ${type} client script "${name}".`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const existing = await client.listRecords<{ sys_id: SnReference }>(
+          'sys_script_client',
+          `name=${name}^table=${table}`,
+          ['sys_id'],
+          1,
+        );
+
+        if (existing.length > 0) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: [
+                  `Client script already exists — skipped.`,
+                  ``,
+                  `name:   ${name}`,
+                  `table:  ${table}`,
+                  `sys_id: ${resolveValue(existing[0].sys_id)}`,
+                ].join('\n'),
+              },
+            ],
+          };
+        }
+
+        const body: Record<string, unknown> = {
+          name,
+          table,
+          type,
+          script,
+          active: String(active),
+          ui_type: UI_TYPE_MAP[ui_type],
+          global: String(global),
+          applies_extended: String(applies_extended),
+          isolate_script: String(isolate_script),
+        };
+
+        if (field !== undefined) body.field = field;
+        if (view !== undefined) body.view = view;
+        if (order !== undefined) body.order = String(order);
+        if (description !== undefined) body.description = description;
+        if (messages !== undefined) body.messages = messages;
+
+        const record = await client.createRecord<{ sys_id: SnReference }>(
+          'sys_script_client',
+          body,
+        );
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: [
+                `Client script created successfully.`,
+                ``,
+                `name:   ${name}`,
+                `table:  ${table}`,
+                `type:   ${type}`,
+                `field:  ${field ?? '—'}`,
+                `sys_id: ${resolveValue(record.sys_id)}`,
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  registry.registerTool(
+    'update_client_script',
+    {
+      access: 'write',
+      title: 'Update Client Script',
+      description: [
+        'Updates fields on an existing sys_script_client record.',
+        '',
+        'Pass only the fields you want to change — omitted fields are left unchanged.',
+        'Requires the sys_id of the client script to update.',
+      ].join('\n'),
+      inputSchema: ClientScriptUpdate,
+      annotations: {
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({
+      sys_id,
+      name,
+      table,
+      type,
+      field,
+      script,
+      active,
+      ui_type,
+      global,
+      view,
+      applies_extended,
+      isolate_script,
+      order,
+      description,
+      messages,
+    }) => {
+      try {
+        if (!isSysId(sys_id)) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `"${sys_id}" is not a valid client script sys_id.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const body: Record<string, unknown> = {};
+        if (name !== undefined) body.name = name;
+        if (table !== undefined) body.table = table;
+        if (type !== undefined) body.type = type;
+        if (field !== undefined) body.field = field;
+        if (script !== undefined) body.script = script;
+        if (active !== undefined) body.active = String(active);
+        if (ui_type !== undefined) body.ui_type = UI_TYPE_MAP[ui_type];
+        if (global !== undefined) body.global = String(global);
+        if (view !== undefined) body.view = view;
+        if (applies_extended !== undefined)
+          body.applies_extended = String(applies_extended);
+        if (isolate_script !== undefined)
+          body.isolate_script = String(isolate_script);
+        if (order !== undefined) body.order = String(order);
+        if (description !== undefined) body.description = description;
+        if (messages !== undefined) body.messages = messages;
+
+        if (Object.keys(body).length === 0) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `No fields to update — all values were omitted.`,
+              },
+            ],
+          };
+        }
+
+        await client.patchRecord<unknown>('sys_script_client', sys_id, body);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: [
+                `Client script updated successfully.`,
+                ``,
+                `sys_id:         ${sys_id}`,
+                `Updated fields: ${Object.keys(body).join(', ')}`,
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+}

--- a/src/tools/scripts/index.ts
+++ b/src/tools/scripts/index.ts
@@ -1,6 +1,7 @@
 import type { ServiceNowClient } from '../../clients/servicenow.js';
 import type { ToolRegistry } from '../registry.js';
 import { registerBusinessRuleTools } from './business-rules.js';
+import { registerClientScriptTools } from './client-scripts.js';
 import { registerScriptIncludeTools } from './script-includes.js';
 
 export function registerScriptTools(
@@ -10,4 +11,5 @@ export function registerScriptTools(
   const scripts = registry.scoped('scripts');
   registerScriptIncludeTools(scripts, client);
   registerBusinessRuleTools(scripts, client);
+  registerClientScriptTools(scripts, client);
 }

--- a/src/tools/scripts/schemas.ts
+++ b/src/tools/scripts/schemas.ts
@@ -220,3 +220,139 @@ export const BusinessRuleUpdate = BusinessRuleBase.partial().extend({
     .min(1)
     .describe('sys_id of the sys_script record to update.'),
 });
+
+// ── Client Script ──────────────────────────────────────────────────────
+
+const ClientScriptBase = z.object({
+  name: z.string().min(1).describe('Name of the client script.'),
+  table: z
+    .string()
+    .min(1)
+    .describe(
+      "Internal name of the table the script runs on, e.g. 'incident' — NOT the label. " +
+        'Best practice: scope client scripts to a single table; keep them short and focused.',
+    ),
+  type: z
+    .enum(['onLoad', 'onChange', 'onSubmit', 'onCellEdit'])
+    .describe(
+      'When the script fires. ' +
+        'onLoad=once when the form renders (set defaults, read-only/mandatory state); ' +
+        'onChange=a specific field changes — requires field; ' +
+        'onSubmit=on form submit — return false to abort the save; ' +
+        'onCellEdit=inline edit of a cell in a list — requires field.',
+    ),
+  field: z
+    .string()
+    .optional()
+    .describe(
+      'Internal name of the field to watch. ' +
+        "REQUIRED when type is 'onChange' or 'onCellEdit'; ignored for onLoad/onSubmit.",
+    ),
+  script: z
+    .string()
+    .min(1)
+    .describe(
+      'Client-side JavaScript. Use the standard signature for the type, e.g. ' +
+        'onChange(control, oldValue, newValue, isLoading, isTemplate) — return early when isLoading is true. ' +
+        'Use the g_form / g_user API. Never make synchronous server calls: use GlideAjax getXMLAnswer() ' +
+        'or async GlideRecord. When setting a reference field, set its display value at the same time ' +
+        'to avoid an extra server round-trip.',
+    ),
+  active: z.boolean().optional().describe('Whether the script is active.'),
+  ui_type: z
+    .enum(['desktop', 'mobile', 'all'])
+    .optional()
+    .describe(
+      "Where the script applies: 'desktop' (platform UI), " +
+        "'mobile' (mobile / Service Portal), or 'all' (both).",
+    ),
+  global: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true the script applies across all form views. ' +
+        'Set false to limit it to one view, then set view.',
+    ),
+  view: z
+    .string()
+    .optional()
+    .describe(
+      'Form view the script is limited to. Only used when global=false.',
+    ),
+  applies_extended: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true the script is inherited by tables that extend this table (the "Inherited" flag).',
+    ),
+  isolate_script: z
+    .boolean()
+    .optional()
+    .describe(
+      'Run the script in an isolated scope with no access to the global window/DOM. ' +
+        'Keep true (the secure, recommended default); set false only for legacy scripts that need window globals.',
+    ),
+  order: z
+    .number()
+    .int()
+    .optional()
+    .describe(
+      'Execution sequence among scripts of the same type on the table. Lower runs first.',
+    ),
+  description: z
+    .string()
+    .optional()
+    .describe('Optional description of what the script does.'),
+  messages: z
+    .string()
+    .optional()
+    .describe(
+      'Newline-separated messages to pre-register for getMessage() lookups on the client.',
+    ),
+});
+
+export const ClientScriptCreate = ClientScriptBase.extend({
+  active: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe('Whether the script is active. Defaults to true.'),
+  ui_type: z
+    .enum(['desktop', 'mobile', 'all'])
+    .optional()
+    .default('all')
+    .describe(
+      "Where the script applies: 'desktop' (platform UI), " +
+        "'mobile' (mobile / Service Portal), or 'all' (both). Defaults to 'all'.",
+    ),
+  global: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe(
+      'When true the script applies across all form views. ' +
+        'Set false to limit it to one view, then set view. Defaults to true.',
+    ),
+  applies_extended: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(
+      'When true the script is inherited by tables that extend this table. Defaults to false.',
+    ),
+  isolate_script: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe(
+      'Run the script in an isolated scope with no access to the global window/DOM. ' +
+        'Defaults to true (secure default); set false only for legacy scripts that need window globals.',
+    ),
+});
+
+export const ClientScriptUpdate = ClientScriptBase.partial().extend({
+  sys_id: z
+    .string()
+    .min(1)
+    .describe('sys_id of the sys_script_client record to update.'),
+});


### PR DESCRIPTION
## What this changes

Adds two new tools for managing **table client scripts** (`sys_script_client`) — the browser-side form scripts that run on `onLoad` / `onChange` / `onSubmit` / `onCellEdit`. This complements the existing *catalog* client script tools (which target catalog item forms); the README now disambiguates the two as **Client scripts (catalog)** and **Client scripts (form)**.

- `create_client_script` — creates a `sys_script_client` record. Validates that `field` is supplied for `onChange`/`onCellEdit` types, maps the `ui_type` enum (`desktop`/`mobile`/`all`) to ServiceNow's internal codes, and is **idempotent**: if a script with the same `name` on the same `table` already exists, it returns the existing record instead of creating a duplicate.
- `update_client_script` — patches an existing `sys_script_client` by `sys_id`, applying only the fields supplied and leaving the rest untouched.

Both tools live in the `scripts` domain (`src/tools/scripts/client-scripts.ts`), are wired through the domain `index.ts`, and bring the documented tool count to **62 across 13 domains**.

## How it was verified

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test` passing (35 tests across the new `client-scripts.test.ts` and updated `registry.test.ts`)
- [x] Exercised against a live ServiceNow PDI (for tool changes)

## Notes

- `ui_type` accepts the friendly enum `desktop` / `mobile` / `all` and is mapped to the internal `0` / `1` / `10` codes before the API call.
- Per the tool description: client scripts run **before** UI policies, so avoid targeting the same field with both unless the UI policy is intended to win.
- For server-side logic use `create_business_rule`; for catalog item forms use the catalog client script tools.
