### PR TITLE
feat: add events tools — registry, queues, script actions, and runtim…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Built and maintained by **Veldev** — an AI assistant for ServiceNow developers
 
 ## Features
 
-62 tools across 13 domains:
+73 tools across 14 domains:
 
 | Domain | What it covers |
 |---|---|
@@ -27,6 +27,7 @@ Built and maintained by **Veldev** — an AI assistant for ServiceNow developers
 | **Background scripts** | Schedule server-side JavaScript snippets via `sys_trigger` |
 | **Fix scripts** | Create, update, and run `sys_script_fix` records — stored server-side scripts for data and config repairs |
 | **Scheduled jobs** | Create, update, list, get, and run-now scheduled jobs (`sysauto`) — script executions, scheduled emails of reports, and template-based record generation |
+| **Events** | Register events (`sysevent_register`), create custom processing queues (`sysevent_queue`) and script actions (`sysevent_script_action`), fire events at runtime via `gs.eventQueue()`, and list/get any of them |
 | **Generic Table CRUD** | Query, fetch, create, and update records in any ServiceNow table |
 | **ATF (Automated Test Framework)** | Create tests and suites, add and configure steps with cross-step output mapping, browse step configs and their input/output schemas |
 
@@ -224,6 +225,8 @@ Create a fix script called "Backfill Incident SLAs" that queries all incidents m
 
 Run the fix script with sys_id 18f9eee1c3d1479043e1fc0d0501315e
 
+Register an event "x_acme.contract.signed" on a custom queue, then create a script action that emails the account owner when it fires
+
 Create an update set called "VPN Catalog Work" and make it my current set
 
 List my in-progress update sets, then switch to "VPN Catalog Work"
@@ -308,7 +311,7 @@ For production self-hosting:
 In gateway mode (`CREDENTIAL_PROVIDER=header`) the server trusts two headers set by the proxy in front of it. They are only meaningful behind an authenticating proxy that sets them itself and strips any client-supplied values — never expose the server directly to clients with these headers enabled.
 
 - **`X-MCP-Access`** (security boundary) — per-request write grant. With `ACCESS_ENFORCEMENT=on`, a write tool call is denied unless the request carries this header with value `write` (default-deny, checked on every request).
-- **`X-MCP-Toolsets`** (UX, not security) — comma-separated toolset names (`atf`, `catalog`, `diagnostics`, `records`, `scripts`, `update-sets`), read once from the session-creating request. Only the named toolsets' tools are registered for that session, trimming the tool list the model sees. Unknown names are ignored with a warning; if the header resolves to no known toolset, all toolsets register (fail-open). This filter never denies anything — write protection is `X-MCP-Access`'s job.
+- **`X-MCP-Toolsets`** (UX, not security) — comma-separated toolset names (`atf`, `catalog`, `diagnostics`, `events`, `records`, `scripts`, `update-sets`), read once from the session-creating request. Only the named toolsets' tools are registered for that session, trimming the tool list the model sees. Unknown names are ignored with a warning; if the header resolves to no known toolset, all toolsets register (fail-open). This filter never denies anything — write protection is `X-MCP-Access`'s job.
 
 ---
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import type { ServiceNowClient } from './clients/servicenow.js';
 import { registerAtfTools } from './tools/atf/index.js';
 import { registerCatalogTools } from './tools/catalog/index.js';
 import { registerDiagnosticsTools } from './tools/diagnostics/index.js';
+import { registerEventTools } from './tools/events/index.js';
 import { registerRecordTools } from './tools/records/index.js';
 import { ToolRegistry, type ToolRegistryOptions } from './tools/registry.js';
 import { registerScriptTools } from './tools/scripts/index.js';
@@ -24,6 +25,7 @@ export function buildServer(
   registerDiagnosticsTools(registry, snClient);
   registerRecordTools(registry, snClient);
   registerAtfTools(registry, snClient);
+  registerEventTools(registry, snClient);
 
   return { server, registry };
 }

--- a/src/tools/events/event-queues.test.ts
+++ b/src/tools/events/event-queues.test.ts
@@ -1,0 +1,125 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import { buildTestPair, firstText } from '../../tests/helpers.js';
+import { registerEventQueueTools } from './event-queues.js';
+
+const NEW_SYS_ID = 'aaaa1111bbbb2222aaaa1111bbbb2222';
+const EXISTING_SYS_ID = 'cccc3333dddd4444cccc3333dddd4444';
+
+const ref = (value: string) => ({ value, display_value: value });
+
+function buildMockClient(): ServiceNowClient {
+  return {
+    listRecords: vi.fn().mockResolvedValue([]),
+    createRecord: vi.fn().mockResolvedValue({ sys_id: ref(NEW_SYS_ID) }),
+    patchRecord: vi.fn().mockResolvedValue({}),
+    getInstanceUrl: vi.fn().mockReturnValue('https://dev.example.com'),
+  } as unknown as ServiceNowClient;
+}
+
+describe('event queue tools (in-memory MCP)', () => {
+  let mcpClient: Client;
+  let teardown: () => Promise<void>;
+
+  beforeEach(async () => {
+    const pair = await buildTestPair(
+      registerEventQueueTools,
+      buildMockClient(),
+    );
+    mcpClient = pair.mcpClient;
+    teardown = pair.teardown;
+  });
+
+  afterEach(async () => {
+    await teardown();
+  });
+
+  describe('create_event_queue', () => {
+    it('sets the default provider and converts poll_interval_seconds to a duration', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerEventQueueTools, mockClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'create_event_queue',
+          arguments: {
+            queue: 'acme_queue',
+            processing_order: 'sequential',
+            poll_interval_seconds: 90,
+            job_config_value: 3,
+          },
+        });
+        expect(firstText(result)).toContain('Event queue created');
+        expect(mockClient.createRecord).toHaveBeenCalledWith(
+          'sysevent_queue',
+          expect.objectContaining({
+            queue: 'acme_queue',
+            provider: '44af4464431212108da9a574a9b8f2f5',
+            processing_order: 'sequential',
+            poll_interval: '1970-01-01 00:01:30',
+            job_config_value: '3',
+          }),
+        );
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('rejects an invalid queue name', async () => {
+      const result = await mcpClient.callTool({
+        name: 'create_event_queue',
+        arguments: { queue: 'Bad Name' },
+      });
+      expect(result.isError).toBe(true);
+    });
+
+    it('is idempotent on queue name', async () => {
+      const idempotentClient = {
+        ...buildMockClient(),
+        listRecords: vi
+          .fn()
+          .mockResolvedValue([{ sys_id: ref(EXISTING_SYS_ID) }]),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(
+        registerEventQueueTools,
+        idempotentClient,
+      );
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'create_event_queue',
+          arguments: { queue: 'acme_queue' },
+        });
+        expect(firstText(result)).toContain('already exists');
+        expect(idempotentClient.createRecord).not.toHaveBeenCalled();
+      } finally {
+        await pair.teardown();
+      }
+    });
+  });
+
+  describe('list_event_queues', () => {
+    it('summarizes matching queues', async () => {
+      const listClient = {
+        ...buildMockClient(),
+        listRecords: vi.fn().mockResolvedValue([
+          {
+            sys_id: ref(NEW_SYS_ID),
+            queue: ref('acme_queue'),
+            processing_order: ref('parallel'),
+            poll_interval: ref('30 Seconds'),
+          },
+        ]),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(registerEventQueueTools, listClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'list_event_queues',
+          arguments: {},
+        });
+        expect(firstText(result)).toContain('acme_queue');
+      } finally {
+        await pair.teardown();
+      }
+    });
+  });
+});

--- a/src/tools/events/event-queues.ts
+++ b/src/tools/events/event-queues.ts
@@ -1,0 +1,262 @@
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import type { SnReference } from '../../types/servicenow.js';
+import {
+  handleError,
+  isSysId,
+  resolveDisplay,
+  resolveValue,
+} from '../helpers.js';
+import type { ToolRegistrar } from '../registry.js';
+import {
+  EventQueueCreate,
+  EventQueueList,
+  EventQueueUpdate,
+} from './schemas.js';
+
+const TABLE = 'sysevent_queue';
+
+// Default "System Queue" provider — sysevent_queue.provider is mandatory and this
+// is the platform default (sysevent_queue.dictionary default_value).
+const DEFAULT_PROVIDER = '44af4464431212108da9a574a9b8f2f5';
+
+type SnRecord = Record<string, SnReference | undefined>;
+
+const val = (r: SnRecord, f: string): string =>
+  r[f] ? resolveValue(r[f] as SnReference) : '';
+const disp = (r: SnRecord, f: string): string =>
+  r[f] ? resolveDisplay(r[f] as SnReference) : '';
+
+/**
+ * poll_interval is a glide_duration, stored as a date/time offset from the
+ * 1970-01-01 epoch: 30s → "1970-01-01 00:00:30", 1 day → "1970-01-02 00:00:00".
+ */
+function secondsToDuration(seconds: number): string {
+  const d = new Date(Date.UTC(1970, 0, 1) + seconds * 1000);
+  return d.toISOString().slice(0, 19).replace('T', ' ');
+}
+
+function recordUrl(client: ServiceNowClient, sysId: string): string {
+  return `${client.getInstanceUrl()}/${TABLE}.do?sys_id=${sysId}`;
+}
+
+interface QueueInput {
+  description?: string;
+  processing_order?: 'parallel' | 'sequential';
+  job_config?: 'jobs_per_node' | 'job_count';
+  job_config_value?: number;
+  poll_interval_seconds?: number;
+  automatic_processing?: boolean;
+  suffix?: string;
+}
+
+function applyQueueFields(
+  body: Record<string, unknown>,
+  input: QueueInput,
+): void {
+  if (input.description !== undefined) body.description = input.description;
+  if (input.processing_order !== undefined)
+    body.processing_order = input.processing_order;
+  if (input.job_config !== undefined) body.job_config = input.job_config;
+  if (input.job_config_value !== undefined)
+    body.job_config_value = String(input.job_config_value);
+  if (input.poll_interval_seconds !== undefined)
+    body.poll_interval = secondsToDuration(input.poll_interval_seconds);
+  if (input.automatic_processing !== undefined)
+    body.automatic_processing = String(input.automatic_processing);
+  if (input.suffix !== undefined) body.suffix = input.suffix;
+}
+
+export function registerEventQueueTools(
+  registry: ToolRegistrar,
+  client: ServiceNowClient,
+): void {
+  registry.registerTool(
+    'create_event_queue',
+    {
+      access: 'write',
+      title: 'Create Event Queue',
+      description: [
+        'Creates a custom event processing queue (sysevent_queue). Event registrations',
+        'route to it by setting their `queue` field to this queue name.',
+        '',
+        'WHEN TO USE: when a workflow fires a high volume of events that would otherwise',
+        "starve the shared 'DEFAULT' queue — give them an isolated queue.",
+        '',
+        'queue must be lowercase letters/digits/underscores only. processing_order',
+        "defaults to 'parallel'; use 'sequential' only when events must be processed in",
+        'order. poll_interval_seconds defaults to 30.',
+        '',
+        'Idempotent: if a queue with the same name already exists, its sys_id is returned',
+        'and no new record is created.',
+      ].join('\n'),
+      inputSchema: EventQueueCreate,
+      annotations: {
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({ queue, ...rest }) => {
+      try {
+        const existing = await client.listRecords<SnRecord>(
+          TABLE,
+          `queue=${queue}`,
+          ['sys_id'],
+          1,
+        );
+        if (existing.length > 0) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: [
+                  `Event queue "${queue}" already exists — skipped.`,
+                  `sys_id: ${val(existing[0], 'sys_id')}`,
+                ].join('\n'),
+              },
+            ],
+          };
+        }
+
+        const body: Record<string, unknown> = {
+          queue,
+          provider: DEFAULT_PROVIDER,
+        };
+        applyQueueFields(body, rest);
+
+        const record = await client.createRecord<SnRecord>(TABLE, body);
+        const sys_id = val(record, 'sys_id');
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: [
+                'Event queue created.',
+                '',
+                `queue:            ${queue}`,
+                `processing_order: ${rest.processing_order ?? 'parallel'}`,
+                `poll_interval:    ${rest.poll_interval_seconds ?? 30}s`,
+                `sys_id:           ${sys_id}`,
+                `URL:              ${recordUrl(client, sys_id)}`,
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  registry.registerTool(
+    'update_event_queue',
+    {
+      access: 'write',
+      title: 'Update Event Queue',
+      description: [
+        'Updates fields on an existing sysevent_queue record.',
+        'Pass only the fields you want to change — omitted fields are left unchanged.',
+      ].join('\n'),
+      inputSchema: EventQueueUpdate,
+      annotations: {
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({ sys_id, queue, ...rest }) => {
+      try {
+        if (!isSysId(sys_id))
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `"${sys_id}" is not a valid sysevent_queue sys_id.`,
+              },
+            ],
+            isError: true,
+          };
+
+        const body: Record<string, unknown> = {};
+        if (queue !== undefined) body.queue = queue;
+        applyQueueFields(body, rest);
+
+        if (Object.keys(body).length === 0) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'No fields to update — all values were omitted.',
+              },
+            ],
+          };
+        }
+
+        await client.patchRecord<unknown>(TABLE, sys_id, body);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: [
+                'Event queue updated successfully.',
+                '',
+                `sys_id:         ${sys_id}`,
+                `Updated fields: ${Object.keys(body).join(', ')}`,
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  registry.registerTool(
+    'list_event_queues',
+    {
+      access: 'read',
+      title: 'List Event Queues',
+      description: [
+        'Lists custom event processing queues (sysevent_queue), optionally filtered by',
+        'name substring.',
+      ].join('\n'),
+      inputSchema: EventQueueList,
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async ({ name_contains, limit }) => {
+      try {
+        const clauses: string[] = [];
+        if (name_contains) clauses.push(`queueLIKE${name_contains}`);
+        clauses.push('ORDERBYqueue');
+
+        const rows = await client.listRecords<SnRecord>(
+          TABLE,
+          clauses.join('^'),
+          [
+            'sys_id',
+            'queue',
+            'processing_order',
+            'poll_interval',
+            'automatic_processing',
+          ],
+          limit,
+        );
+
+        const summary = rows.length
+          ? rows
+              .map(
+                (r) =>
+                  `${val(r, 'queue')} — ${disp(r, 'processing_order')} — poll ${disp(r, 'poll_interval')} — ${val(r, 'sys_id')}`,
+              )
+              .join('\n')
+          : 'No event queues matched.';
+
+        return { content: [{ type: 'text' as const, text: summary }] };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+}

--- a/src/tools/events/event-registrations.test.ts
+++ b/src/tools/events/event-registrations.test.ts
@@ -1,0 +1,201 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import { SnApiError } from '../../clients/servicenow.js';
+import { buildTestPair, firstText } from '../../tests/helpers.js';
+import { registerEventRegistrationTools } from './event-registrations.js';
+
+const NEW_SYS_ID = 'aaaa1111bbbb2222aaaa1111bbbb2222';
+const EXISTING_SYS_ID = 'cccc3333dddd4444cccc3333dddd4444';
+
+const ref = (value: string) => ({ value, display_value: value });
+
+function buildMockClient(): ServiceNowClient {
+  return {
+    listRecords: vi.fn().mockResolvedValue([]),
+    createRecord: vi.fn().mockResolvedValue({ sys_id: ref(NEW_SYS_ID) }),
+    patchRecord: vi.fn().mockResolvedValue({}),
+    getRecord: vi.fn(),
+    getInstanceUrl: vi.fn().mockReturnValue('https://dev.example.com'),
+  } as unknown as ServiceNowClient;
+}
+
+describe('event registration tools (in-memory MCP)', () => {
+  let mcpClient: Client;
+  let teardown: () => Promise<void>;
+
+  beforeEach(async () => {
+    const pair = await buildTestPair(
+      registerEventRegistrationTools,
+      buildMockClient(),
+    );
+    mcpClient = pair.mcpClient;
+    teardown = pair.teardown;
+  });
+
+  afterEach(async () => {
+    await teardown();
+  });
+
+  describe('create_event_registration', () => {
+    it('creates the record and maps caller_access enum to its code', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(
+        registerEventRegistrationTools,
+        mockClient,
+      );
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'create_event_registration',
+          arguments: {
+            event_name: 'x_acme.thing.done',
+            table: 'incident',
+            queue: 'acme_queue',
+            caller_access: 'restriction',
+          },
+        });
+        const text = firstText(result);
+        expect(text).toContain('Event registered');
+        expect(text).toContain(NEW_SYS_ID);
+        expect(mockClient.createRecord).toHaveBeenCalledWith(
+          'sysevent_register',
+          expect.objectContaining({
+            event_name: 'x_acme.thing.done',
+            table: 'incident',
+            queue: 'acme_queue',
+            caller_access: '2',
+          }),
+        );
+        expect(result.isError).toBeFalsy();
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('is idempotent on event_name', async () => {
+      const idempotentClient = {
+        ...buildMockClient(),
+        listRecords: vi
+          .fn()
+          .mockResolvedValue([{ sys_id: ref(EXISTING_SYS_ID) }]),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(
+        registerEventRegistrationTools,
+        idempotentClient,
+      );
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'create_event_registration',
+          arguments: { event_name: 'x_acme.thing.done' },
+        });
+        expect(firstText(result)).toContain('already registered');
+        expect(idempotentClient.createRecord).not.toHaveBeenCalled();
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('surfaces SnApiError with status', async () => {
+      const errorClient = {
+        ...buildMockClient(),
+        createRecord: vi
+          .fn()
+          .mockRejectedValue(
+            new SnApiError(403, 'Forbidden', 'ACL', 'https://example.com'),
+          ),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(
+        registerEventRegistrationTools,
+        errorClient,
+      );
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'create_event_registration',
+          arguments: { event_name: 'x_acme.thing.done' },
+        });
+        expect(result.isError).toBe(true);
+        expect(firstText(result)).toContain('403');
+      } finally {
+        await pair.teardown();
+      }
+    });
+  });
+
+  describe('update_event_registration', () => {
+    it('patches only supplied fields', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(
+        registerEventRegistrationTools,
+        mockClient,
+      );
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'update_event_registration',
+          arguments: { sys_id: EXISTING_SYS_ID, queue: 'other_queue' },
+        });
+        expect(firstText(result)).toContain('updated successfully');
+        expect(mockClient.patchRecord).toHaveBeenCalledWith(
+          'sysevent_register',
+          EXISTING_SYS_ID,
+          { queue: 'other_queue' },
+        );
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('rejects an invalid sys_id', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_event_registration',
+        arguments: { sys_id: 'nope', queue: 'q' },
+      });
+      expect(result.isError).toBe(true);
+      expect(firstText(result)).toContain('not a valid');
+    });
+  });
+
+  describe('get_event', () => {
+    it('returns a two-block summary with its listening script actions', async () => {
+      const richClient = {
+        ...buildMockClient(),
+        getRecord: vi.fn().mockResolvedValue({
+          sys_id: ref(EXISTING_SYS_ID),
+          event_name: ref('x_acme.thing.done'),
+          table: ref('incident'),
+          queue: ref('acme_queue'),
+        }),
+        listRecords: vi
+          .fn()
+          // first call: script actions; second call: queue lookup
+          .mockResolvedValueOnce([
+            {
+              sys_id: ref('11112222333344445555666677778888'),
+              name: ref('Handle Thing'),
+              active: ref('true'),
+              order: ref('100'),
+              synchronous: ref('false'),
+            },
+          ])
+          .mockResolvedValueOnce([{ sys_id: ref('q1') }]),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(
+        registerEventRegistrationTools,
+        richClient,
+      );
+      try {
+        const result = (await pair.mcpClient.callTool({
+          name: 'get_event',
+          arguments: { sys_id: EXISTING_SYS_ID },
+        })) as { content: Array<{ text: string }>; isError?: boolean };
+        expect(result.content).toHaveLength(2);
+        expect(result.content[0].text).toContain('Handle Thing');
+        const json = JSON.parse(result.content[1].text);
+        expect(json.event_name).toBe('x_acme.thing.done');
+        expect(json.script_actions).toHaveLength(1);
+        expect(json.queue_registered).toBe(true);
+      } finally {
+        await pair.teardown();
+      }
+    });
+  });
+});

--- a/src/tools/events/event-registrations.ts
+++ b/src/tools/events/event-registrations.ts
@@ -1,0 +1,358 @@
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import type { SnReference } from '../../types/servicenow.js';
+import {
+  handleError,
+  isSysId,
+  resolveDisplay,
+  resolveValue,
+} from '../helpers.js';
+import type { ToolRegistrar } from '../registry.js';
+import {
+  EventGet,
+  EventList,
+  EventRegistrationCreate,
+  EventRegistrationUpdate,
+} from './schemas.js';
+
+const TABLE = 'sysevent_register';
+const SCRIPT_ACTION_TABLE = 'sysevent_script_action';
+const QUEUE_TABLE = 'sysevent_queue';
+
+type SnRecord = Record<string, SnReference | undefined>;
+
+const val = (r: SnRecord, f: string): string =>
+  r[f] ? resolveValue(r[f] as SnReference) : '';
+const disp = (r: SnRecord, f: string): string =>
+  r[f] ? resolveDisplay(r[f] as SnReference) : '';
+
+const CALLER_ACCESS: Record<string, string> = {
+  tracking: '1',
+  restriction: '2',
+};
+
+function recordUrl(client: ServiceNowClient, sysId: string): string {
+  return `${client.getInstanceUrl()}/${TABLE}.do?sys_id=${sysId}`;
+}
+
+export function registerEventRegistrationTools(
+  registry: ToolRegistrar,
+  client: ServiceNowClient,
+): void {
+  registry.registerTool(
+    'create_event_registration',
+    {
+      access: 'write',
+      title: 'Register Event',
+      description: [
+        'Registers an event in the Event Registry (sysevent_register) so it can be',
+        'fired with gs.eventQueue() and listened to by script actions and notifications.',
+        '',
+        "event_name follows the '<table>.<verb>' convention, e.g. 'incident.commented'.",
+        'The table prefix is not added automatically — include it yourself.',
+        'Set `queue` to route processing to a custom queue (see create_event_queue);',
+        "omit it to use the built-in 'DEFAULT' queue.",
+        '',
+        'Idempotent: if an event with the same event_name already exists, its sys_id is',
+        'returned and no new record is created.',
+      ].join('\n'),
+      inputSchema: EventRegistrationCreate,
+      annotations: {
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({
+      event_name,
+      table,
+      queue,
+      description,
+      fired_by,
+      priority,
+      suffix,
+      caller_access,
+    }) => {
+      try {
+        const existing = await client.listRecords<SnRecord>(
+          TABLE,
+          `event_name=${event_name}`,
+          ['sys_id'],
+          1,
+        );
+        if (existing.length > 0) {
+          const sys_id = val(existing[0], 'sys_id');
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: [
+                  `Event "${event_name}" is already registered — skipped.`,
+                  `sys_id: ${sys_id}`,
+                ].join('\n'),
+              },
+            ],
+          };
+        }
+
+        const body: Record<string, unknown> = { event_name };
+        if (table !== undefined) body.table = table;
+        if (queue !== undefined) body.queue = queue;
+        if (description !== undefined) body.description = description;
+        if (fired_by !== undefined) body.fired_by = fired_by;
+        if (priority !== undefined) body.priority = String(priority);
+        if (suffix !== undefined) body.suffix = suffix;
+        if (caller_access !== undefined)
+          body.caller_access = CALLER_ACCESS[caller_access];
+
+        const record = await client.createRecord<SnRecord>(TABLE, body);
+        const sys_id = val(record, 'sys_id');
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: [
+                'Event registered.',
+                '',
+                `event_name: ${event_name}`,
+                `table:      ${table ?? '—'}`,
+                `queue:      ${queue ?? 'DEFAULT'}`,
+                `sys_id:     ${sys_id}`,
+                `URL:        ${recordUrl(client, sys_id)}`,
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  registry.registerTool(
+    'update_event_registration',
+    {
+      access: 'write',
+      title: 'Update Event Registration',
+      description: [
+        'Updates fields on an existing sysevent_register record.',
+        'Pass only the fields you want to change — omitted fields are left unchanged.',
+      ].join('\n'),
+      inputSchema: EventRegistrationUpdate,
+      annotations: {
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({
+      sys_id,
+      event_name,
+      table,
+      queue,
+      description,
+      fired_by,
+      priority,
+      suffix,
+      caller_access,
+    }) => {
+      try {
+        if (!isSysId(sys_id))
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `"${sys_id}" is not a valid sysevent_register sys_id.`,
+              },
+            ],
+            isError: true,
+          };
+
+        const body: Record<string, unknown> = {};
+        if (event_name !== undefined) body.event_name = event_name;
+        if (table !== undefined) body.table = table;
+        if (queue !== undefined) body.queue = queue;
+        if (description !== undefined) body.description = description;
+        if (fired_by !== undefined) body.fired_by = fired_by;
+        if (priority !== undefined) body.priority = String(priority);
+        if (suffix !== undefined) body.suffix = suffix;
+        if (caller_access !== undefined)
+          body.caller_access = CALLER_ACCESS[caller_access];
+
+        if (Object.keys(body).length === 0) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'No fields to update — all values were omitted.',
+              },
+            ],
+          };
+        }
+
+        await client.patchRecord<unknown>(TABLE, sys_id, body);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: [
+                'Event registration updated successfully.',
+                '',
+                `sys_id:         ${sys_id}`,
+                `Updated fields: ${Object.keys(body).join(', ')}`,
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  registry.registerTool(
+    'list_events',
+    {
+      access: 'read',
+      title: 'List Registered Events',
+      description: [
+        'Lists events from the Event Registry (sysevent_register), optionally filtered',
+        'by name substring or table.',
+      ].join('\n'),
+      inputSchema: EventList,
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async ({ name_contains, table, limit }) => {
+      try {
+        const clauses: string[] = [];
+        if (name_contains) clauses.push(`event_nameLIKE${name_contains}`);
+        if (table) clauses.push(`table=${table}`);
+        clauses.push('ORDERBYevent_name');
+
+        const rows = await client.listRecords<SnRecord>(
+          TABLE,
+          clauses.join('^'),
+          ['sys_id', 'event_name', 'table', 'queue', 'description'],
+          limit,
+        );
+
+        const summary = rows.length
+          ? rows
+              .map((r) => {
+                const q = val(r, 'queue') || 'DEFAULT';
+                const tbl = disp(r, 'table');
+                return `${val(r, 'event_name')} — queue ${q}${tbl ? ` — ${tbl}` : ''} — ${val(r, 'sys_id')}`;
+              })
+              .join('\n')
+          : 'No registered events matched.';
+
+        return { content: [{ type: 'text' as const, text: summary }] };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  registry.registerTool(
+    'get_event',
+    {
+      access: 'read',
+      title: 'Get Registered Event',
+      description: [
+        'Reads a single registered event (sysevent_register) with its resolved queue',
+        'and the script actions that listen on it.',
+      ].join('\n'),
+      inputSchema: EventGet,
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async ({ sys_id }) => {
+      try {
+        if (!isSysId(sys_id))
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `"${sys_id}" is not a valid sysevent_register sys_id.`,
+              },
+            ],
+            isError: true,
+          };
+
+        const base = await client.getRecord<SnRecord>(TABLE, sys_id, [
+          'sys_id',
+          'event_name',
+          'table',
+          'queue',
+          'description',
+          'fired_by',
+          'priority',
+          'caller_access',
+        ]);
+
+        const eventName = val(base, 'event_name');
+        const queueName = val(base, 'queue');
+
+        const [actions, queues] = await Promise.all([
+          client.listRecords<SnRecord>(
+            SCRIPT_ACTION_TABLE,
+            `event_name=${eventName}^ORDERBYorder`,
+            ['sys_id', 'name', 'active', 'order', 'synchronous'],
+            50,
+          ),
+          queueName
+            ? client.listRecords<SnRecord>(
+                QUEUE_TABLE,
+                `queue=${queueName}`,
+                ['sys_id', 'queue', 'processing_order', 'poll_interval'],
+                1,
+              )
+            : Promise.resolve<SnRecord[]>([]),
+        ]);
+
+        const listeners = actions.map((a) => ({
+          sys_id: val(a, 'sys_id'),
+          name: disp(a, 'name'),
+          active: val(a, 'active') === 'true',
+          order: val(a, 'order'),
+          synchronous: val(a, 'synchronous') === 'true',
+        }));
+
+        const result = {
+          sys_id: val(base, 'sys_id'),
+          event_name: eventName,
+          table: disp(base, 'table'),
+          queue: queueName || 'DEFAULT',
+          queue_registered: queues.length > 0,
+          description: disp(base, 'description'),
+          fired_by: disp(base, 'fired_by'),
+          priority: val(base, 'priority'),
+          caller_access: disp(base, 'caller_access'),
+          url: recordUrl(client, sys_id),
+          script_actions: listeners,
+        };
+
+        const summary = [
+          `Event:    ${result.event_name} (${result.sys_id})`,
+          `Table:    ${result.table || '—'}`,
+          `Queue:    ${result.queue}${result.queue_registered ? '' : ' (not a custom queue)'}`,
+          `Priority: ${result.priority || '100'}`,
+          `Listeners (script actions): ${listeners.length}`,
+          ...listeners.map(
+            (l) =>
+              `  • ${l.name}${l.active ? '' : ' (inactive)'} — order ${l.order || '100'} — ${l.sys_id}`,
+          ),
+          `URL:      ${result.url}`,
+        ].join('\n');
+
+        return {
+          content: [
+            { type: 'text' as const, text: summary },
+            { type: 'text' as const, text: JSON.stringify(result, null, 2) },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+}

--- a/src/tools/events/fire-event.test.ts
+++ b/src/tools/events/fire-event.test.ts
@@ -1,0 +1,90 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import { buildTestPair, firstText } from '../../tests/helpers.js';
+import { registerFireEventTools } from './fire-event.js';
+
+const RECORD_SYS_ID = 'aaaa1111bbbb2222aaaa1111bbbb2222';
+
+function buildMockClient(): ServiceNowClient {
+  return {
+    executeBackgroundScriptTrigger: vi.fn().mockResolvedValue({
+      success: true,
+      trigger_sys_id: 'trig123',
+      trigger_name: 'MCP_Script_1',
+      next_action: '2026-06-13 00:00:01',
+    }),
+  } as unknown as ServiceNowClient;
+}
+
+describe('fire_event tool (in-memory MCP)', () => {
+  let mcpClient: Client;
+  let teardown: () => Promise<void>;
+  let mockClient: ServiceNowClient;
+
+  beforeEach(async () => {
+    mockClient = buildMockClient();
+    const pair = await buildTestPair(registerFireEventTools, mockClient);
+    mcpClient = pair.mcpClient;
+    teardown = pair.teardown;
+  });
+
+  afterEach(async () => {
+    await teardown();
+  });
+
+  it('fires a bare event via gs.eventQueue with null record', async () => {
+    const result = await mcpClient.callTool({
+      name: 'fire_event',
+      arguments: { event_name: 'x_acme.thing.done', parm1: 'hi' },
+    });
+    expect(firstText(result)).toContain('Event fire requested');
+    const script = (
+      mockClient.executeBackgroundScriptTrigger as ReturnType<typeof vi.fn>
+    ).mock.calls[0][0] as string;
+    expect(script).toContain('var gr = null;');
+    expect(script).toContain(
+      'gs.eventQueue("x_acme.thing.done", gr, "hi", "")',
+    );
+    expect(script).not.toContain('new GlideRecord');
+  });
+
+  it('attaches a record when table + sys_id are provided', async () => {
+    await mcpClient.callTool({
+      name: 'fire_event',
+      arguments: {
+        event_name: 'x_acme.thing.done',
+        record_table: 'incident',
+        record_sys_id: RECORD_SYS_ID,
+      },
+    });
+    const script = (
+      mockClient.executeBackgroundScriptTrigger as ReturnType<typeof vi.fn>
+    ).mock.calls[0][0] as string;
+    expect(script).toContain('new GlideRecord("incident")');
+    expect(script).toContain(`_g.get("${RECORD_SYS_ID}")`);
+  });
+
+  it('errors when only one of table / sys_id is given', async () => {
+    const result = await mcpClient.callTool({
+      name: 'fire_event',
+      arguments: { event_name: 'x_acme.thing.done', record_table: 'incident' },
+    });
+    expect(result.isError).toBe(true);
+    expect(firstText(result)).toContain('must be provided together');
+    expect(mockClient.executeBackgroundScriptTrigger).not.toHaveBeenCalled();
+  });
+
+  it('errors on an invalid record sys_id', async () => {
+    const result = await mcpClient.callTool({
+      name: 'fire_event',
+      arguments: {
+        event_name: 'x_acme.thing.done',
+        record_table: 'incident',
+        record_sys_id: 'not-valid',
+      },
+    });
+    expect(result.isError).toBe(true);
+    expect(firstText(result)).toContain('not a valid');
+  });
+});

--- a/src/tools/events/fire-event.ts
+++ b/src/tools/events/fire-event.ts
@@ -1,0 +1,97 @@
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import { handleError, isSysId } from '../helpers.js';
+import type { ToolRegistrar } from '../registry.js';
+import { FireEvent } from './schemas.js';
+
+export function registerFireEventTools(
+  registry: ToolRegistrar,
+  client: ServiceNowClient,
+): void {
+  registry.registerTool(
+    'fire_event',
+    {
+      access: 'write',
+      title: 'Fire Event',
+      description: [
+        'Fires an event at runtime via gs.eventQueue(), queuing it for processing so',
+        'script actions and event-driven notifications registered on that event name run.',
+        '',
+        'Pass record_table + record_sys_id to attach a record — listeners then receive it',
+        'as `current` (and event.instance = its sys_id). parm1/parm2 are optional strings',
+        'readable as event.parm1 / event.parm2.',
+        '',
+        'Runs a one-shot background script (~1s delay via sys_trigger). The event_name',
+        'should match a registered event (sysevent_register) or no listener will react.',
+      ].join('\n'),
+      inputSchema: FireEvent,
+      annotations: {
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async ({ event_name, record_table, record_sys_id, parm1, parm2 }) => {
+      try {
+        const hasTable = record_table !== undefined;
+        const hasSysId = record_sys_id !== undefined;
+        if (hasTable !== hasSysId) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'record_table and record_sys_id must be provided together (or both omitted).',
+              },
+            ],
+            isError: true,
+          };
+        }
+        if (hasSysId && !isSysId(record_sys_id as string)) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `"${record_sys_id}" is not a valid record sys_id.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        // JSON.stringify yields a safe JS string literal for each interpolated value.
+        const lines: string[] = ['var gr = null;'];
+        if (hasTable && hasSysId) {
+          lines.push(
+            `var _g = new GlideRecord(${JSON.stringify(record_table)});`,
+            `if (_g.get(${JSON.stringify(record_sys_id)})) { gr = _g; }`,
+          );
+        }
+        lines.push(
+          `gs.eventQueue(${JSON.stringify(event_name)}, gr, ${JSON.stringify(parm1 ?? '')}, ${JSON.stringify(parm2 ?? '')});`,
+        );
+        const script = lines.join('\n');
+
+        const result = await client.executeBackgroundScriptTrigger(script);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: [
+                'Event fire requested.',
+                '',
+                `event_name:     ${event_name}`,
+                `record:         ${hasTable ? `${record_table}/${record_sys_id}` : '(none)'}`,
+                `parm1:          ${parm1 ?? ''}`,
+                `parm2:          ${parm2 ?? ''}`,
+                `trigger_sys_id: ${result.trigger_sys_id}`,
+                `next_action:    ${result.next_action}`,
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+}

--- a/src/tools/events/index.ts
+++ b/src/tools/events/index.ts
@@ -1,0 +1,17 @@
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import type { ToolRegistry } from '../registry.js';
+import { registerEventQueueTools } from './event-queues.js';
+import { registerEventRegistrationTools } from './event-registrations.js';
+import { registerFireEventTools } from './fire-event.js';
+import { registerScriptActionTools } from './script-actions.js';
+
+export function registerEventTools(
+  registry: ToolRegistry,
+  client: ServiceNowClient,
+): void {
+  const events = registry.scoped('events');
+  registerEventRegistrationTools(events, client);
+  registerEventQueueTools(events, client);
+  registerScriptActionTools(events, client);
+  registerFireEventTools(events, client);
+}

--- a/src/tools/events/schemas.ts
+++ b/src/tools/events/schemas.ts
@@ -1,0 +1,343 @@
+import { z } from 'zod';
+
+// ── Event Registration (sysevent_register) ─────────────────────────────
+
+const EventRegistrationBase = z.object({
+  event_name: z
+    .string()
+    .min(1)
+    .max(40)
+    .describe(
+      'Name of the event, used in gs.eventQueue() and by script actions. ' +
+        "ServiceNow convention is '<table>.<verb>', e.g. 'incident.commented' or " +
+        "'x_acme_app.approved'. The table prefix is NOT added automatically — include it. " +
+        'Lowercase, dot-separated, no spaces.',
+    ),
+  table: z
+    .string()
+    .optional()
+    .describe(
+      "Internal name of the table this event relates to, e.g. 'incident' — NOT the label. " +
+        'Documentation only; it does not restrict where the event can be fired from.',
+    ),
+  queue: z
+    .string()
+    .max(40)
+    .optional()
+    .describe(
+      'Name of the processing queue that handles this event. Omit to use the ' +
+        "built-in 'DEFAULT' queue. To route to a custom queue, pass that queue's " +
+        'name (the `queue` value of a sysevent_queue record created via create_event_queue).',
+    ),
+  description: z
+    .string()
+    .max(100)
+    .optional()
+    .describe('What the event represents / when it fires.'),
+  fired_by: z
+    .string()
+    .max(100)
+    .optional()
+    .describe(
+      'Free-text note documenting what fires this event (e.g. a business rule name). ' +
+        'Documentation only.',
+    ),
+  priority: z
+    .number()
+    .int()
+    .optional()
+    .describe(
+      'Processing priority; lower runs first. Defaults to 100. Leave default unless ' +
+        'this event must be processed ahead of others in the same queue.',
+    ),
+  suffix: z
+    .string()
+    .max(40)
+    .optional()
+    .describe(
+      'Optional suffix used by some platform features; usually left empty.',
+    ),
+  caller_access: z
+    .enum(['tracking', 'restriction'])
+    .optional()
+    .describe(
+      'Caller access mode. Usually omitted. ' +
+        "'tracking' = Caller Tracking, 'restriction' = Caller Restriction.",
+    ),
+});
+
+export const EventRegistrationCreate = EventRegistrationBase;
+
+export const EventRegistrationUpdate = EventRegistrationBase.partial().extend({
+  sys_id: z
+    .string()
+    .min(1)
+    .describe('sys_id of the sysevent_register record to update.'),
+});
+
+export const EventList = z.object({
+  name_contains: z
+    .string()
+    .optional()
+    .describe('Filter to events whose event_name contains this substring.'),
+  table: z
+    .string()
+    .optional()
+    .describe(
+      "Filter to events registered against this table, e.g. 'incident'.",
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .default(50)
+    .describe('Maximum number of events to return (1–100). Defaults to 50.'),
+});
+
+export const EventGet = z.object({
+  sys_id: z
+    .string()
+    .min(1)
+    .describe('sys_id of the sysevent_register record to read.'),
+});
+
+// ── Event Queue (sysevent_queue) ───────────────────────────────────────
+
+const QUEUE_NAME = z
+  .string()
+  .min(1)
+  .max(40)
+  .regex(
+    /^[a-z0-9_]+$/,
+    'Queue name must use only lowercase letters, digits, and underscores (no spaces or other characters).',
+  );
+
+const EventQueueBase = z.object({
+  queue: QUEUE_NAME.describe(
+    'Unique queue name. Lowercase letters, digits and underscores only — no spaces. ' +
+      'Event registrations route to this queue by referencing this name in their `queue` field.',
+  ),
+  description: z
+    .string()
+    .max(255)
+    .optional()
+    .describe('What this queue is for / which events it handles.'),
+  processing_order: z
+    .enum(['parallel', 'sequential'])
+    .optional()
+    .describe(
+      "'parallel' (default) processes events concurrently across jobs; " +
+        "'sequential' processes one event at a time in order. Use 'sequential' only " +
+        'when event ordering matters.',
+    ),
+  job_config: z
+    .enum(['jobs_per_node', 'job_count'])
+    .optional()
+    .describe(
+      'How processing jobs are scaled. ' +
+        "'jobs_per_node' (default) = create job_config_value jobs per node (scales with cluster); " +
+        "'job_count' = a constant total of job_config_value jobs.",
+    ),
+  job_config_value: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe(
+      'Number of processing jobs (interpreted per job_config). Defaults to 1. ' +
+        'Raise for high-volume queues.',
+    ),
+  poll_interval_seconds: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe(
+      'How often (seconds) the queue polls for new events. Defaults to 30. ' +
+        'Lower means lower latency but more overhead.',
+    ),
+  automatic_processing: z
+    .boolean()
+    .optional()
+    .describe(
+      'Let ServiceNow create and schedule the processing jobs automatically. ' +
+        'Defaults to true — keep true unless you manage the jobs yourself.',
+    ),
+  suffix: z
+    .string()
+    .max(40)
+    .optional()
+    .describe('Optional suffix; usually left empty.'),
+});
+
+export const EventQueueCreate = EventQueueBase;
+
+export const EventQueueUpdate = z
+  .object({
+    sys_id: z
+      .string()
+      .min(1)
+      .describe('sys_id of the sysevent_queue record to update.'),
+    queue: QUEUE_NAME.optional().describe(
+      'Renamed queue name (rarely changed).',
+    ),
+  })
+  .merge(EventQueueBase.omit({ queue: true }).partial());
+
+export const EventQueueList = z.object({
+  name_contains: z
+    .string()
+    .optional()
+    .describe('Filter to queues whose name contains this substring.'),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .default(50)
+    .describe('Maximum number of queues to return (1–100). Defaults to 50.'),
+});
+
+// ── Script Action (sysevent_script_action) ─────────────────────────────
+
+const ScriptActionBase = z.object({
+  name: z.string().min(1).describe('Display name of the script action.'),
+  event_name: z
+    .string()
+    .min(1)
+    .max(40)
+    .describe(
+      'Name of the registered event this action responds to (must match a ' +
+        "sysevent_register event_name, e.g. 'incident.commented'). The action runs " +
+        'each time that event is processed.',
+    ),
+  script: z
+    .string()
+    .min(1)
+    .describe(
+      'Server-side JavaScript that runs when the event fires. The fired event is ' +
+        'available as the global `event` (event.parm1, event.parm2, event.instance = the ' +
+        'triggering record sys_id), and the related GlideRecord as `current` when the ' +
+        'event was fired with one. Put ALL conditional logic here — see condition_script.',
+    ),
+  condition_script: z
+    .string()
+    .max(254)
+    .optional()
+    .describe(
+      'Optional one-line condition. IMPORTANT: `event` and `current` are NOT in scope ' +
+        'here, so this cannot test the triggering record — gate that logic inside `script` ' +
+        'instead. Leave empty in most cases.',
+    ),
+  order: z
+    .number()
+    .int()
+    .optional()
+    .describe(
+      'Execution order among script actions on the same event; lower runs first. Defaults to 100.',
+    ),
+  synchronous: z
+    .boolean()
+    .optional()
+    .describe(
+      'Run inline in the event-processing thread (true) instead of asynchronously (false, default). ' +
+        'Keep false unless ordering against other synchronous handlers is required.',
+    ),
+  active: z
+    .boolean()
+    .optional()
+    .describe('Whether the script action is active.'),
+  description: z
+    .string()
+    .optional()
+    .describe('Optional description of what the script action does.'),
+});
+
+export const ScriptActionCreate = ScriptActionBase.extend({
+  active: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe('Whether the script action is active. Defaults to true.'),
+  synchronous: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(
+      'Run inline (true) instead of asynchronously (false). Defaults to false.',
+    ),
+});
+
+export const ScriptActionUpdate = ScriptActionBase.partial().extend({
+  sys_id: z
+    .string()
+    .min(1)
+    .describe('sys_id of the sysevent_script_action record to update.'),
+});
+
+export const ScriptActionList = z.object({
+  event_name: z
+    .string()
+    .optional()
+    .describe('Filter to script actions listening on this exact event name.'),
+  name_contains: z
+    .string()
+    .optional()
+    .describe('Filter to script actions whose name contains this substring.'),
+  active_only: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe('Return only active script actions. Defaults to false.'),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .default(50)
+    .describe(
+      'Maximum number of script actions to return (1–100). Defaults to 50.',
+    ),
+});
+
+// ── Fire Event (runtime, gs.eventQueue) ────────────────────────────────
+
+export const FireEvent = z.object({
+  event_name: z
+    .string()
+    .min(1)
+    .describe(
+      'Name of the event to fire (should match a registered sysevent_register event so ' +
+        'script actions / notifications listen for it). Fires via gs.eventQueue().',
+    ),
+  record_table: z
+    .string()
+    .optional()
+    .describe(
+      "Internal table of a record to attach to the event, e.g. 'incident'. " +
+        'Required together with record_sys_id to make `current` available to listeners.',
+    ),
+  record_sys_id: z
+    .string()
+    .optional()
+    .describe(
+      'sys_id of the record to attach. The event is fired with this record as its ' +
+        'GlideRecord. Required together with record_table.',
+    ),
+  parm1: z
+    .string()
+    .optional()
+    .describe(
+      'Optional first parameter, readable as event.parm1 by listeners.',
+    ),
+  parm2: z
+    .string()
+    .optional()
+    .describe(
+      'Optional second parameter, readable as event.parm2 by listeners.',
+    ),
+});

--- a/src/tools/events/script-actions.test.ts
+++ b/src/tools/events/script-actions.test.ts
@@ -1,0 +1,151 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import { buildTestPair, firstText } from '../../tests/helpers.js';
+import { registerScriptActionTools } from './script-actions.js';
+
+const NEW_SYS_ID = 'aaaa1111bbbb2222aaaa1111bbbb2222';
+const EXISTING_SYS_ID = 'cccc3333dddd4444cccc3333dddd4444';
+
+const ref = (value: string) => ({ value, display_value: value });
+
+function buildMockClient(): ServiceNowClient {
+  return {
+    listRecords: vi.fn().mockResolvedValue([]),
+    createRecord: vi.fn().mockResolvedValue({ sys_id: ref(NEW_SYS_ID) }),
+    patchRecord: vi.fn().mockResolvedValue({}),
+    getInstanceUrl: vi.fn().mockReturnValue('https://dev.example.com'),
+  } as unknown as ServiceNowClient;
+}
+
+describe('script action tools (in-memory MCP)', () => {
+  let mcpClient: Client;
+  let teardown: () => Promise<void>;
+
+  beforeEach(async () => {
+    const pair = await buildTestPair(
+      registerScriptActionTools,
+      buildMockClient(),
+    );
+    mcpClient = pair.mcpClient;
+    teardown = pair.teardown;
+  });
+
+  afterEach(async () => {
+    await teardown();
+  });
+
+  describe('create_script_action', () => {
+    it('applies active/synchronous defaults and string-coerces them', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerScriptActionTools, mockClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'create_script_action',
+          arguments: {
+            name: 'Handle Thing',
+            event_name: 'x_acme.thing.done',
+            script: 'gs.info(event.parm1);',
+          },
+        });
+        expect(firstText(result)).toContain('Script action created');
+        expect(mockClient.createRecord).toHaveBeenCalledWith(
+          'sysevent_script_action',
+          expect.objectContaining({
+            name: 'Handle Thing',
+            event_name: 'x_acme.thing.done',
+            active: 'true',
+            synchronous: 'false',
+          }),
+        );
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('is idempotent on name + event_name', async () => {
+      const idempotentClient = {
+        ...buildMockClient(),
+        listRecords: vi
+          .fn()
+          .mockResolvedValue([{ sys_id: ref(EXISTING_SYS_ID) }]),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(
+        registerScriptActionTools,
+        idempotentClient,
+      );
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'create_script_action',
+          arguments: {
+            name: 'Handle Thing',
+            event_name: 'x_acme.thing.done',
+            script: 'gs.info(1);',
+          },
+        });
+        expect(firstText(result)).toContain('already exists');
+        expect(idempotentClient.createRecord).not.toHaveBeenCalled();
+      } finally {
+        await pair.teardown();
+      }
+    });
+  });
+
+  describe('update_script_action', () => {
+    it('rejects an invalid sys_id', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_script_action',
+        arguments: { sys_id: 'bad', active: false },
+      });
+      expect(result.isError).toBe(true);
+      expect(firstText(result)).toContain('not a valid');
+    });
+
+    it('patches supplied fields', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerScriptActionTools, mockClient);
+      try {
+        await pair.mcpClient.callTool({
+          name: 'update_script_action',
+          arguments: { sys_id: EXISTING_SYS_ID, active: false, order: 200 },
+        });
+        expect(mockClient.patchRecord).toHaveBeenCalledWith(
+          'sysevent_script_action',
+          EXISTING_SYS_ID,
+          { active: 'false', order: '200' },
+        );
+      } finally {
+        await pair.teardown();
+      }
+    });
+  });
+
+  describe('list_script_actions', () => {
+    it('summarizes matches with sync/async tag', async () => {
+      const listClient = {
+        ...buildMockClient(),
+        listRecords: vi.fn().mockResolvedValue([
+          {
+            sys_id: ref(NEW_SYS_ID),
+            name: ref('Handle Thing'),
+            event_name: ref('x_acme.thing.done'),
+            active: ref('true'),
+            synchronous: ref('false'),
+          },
+        ]),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(registerScriptActionTools, listClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'list_script_actions',
+          arguments: { event_name: 'x_acme.thing.done' },
+        });
+        const text = firstText(result);
+        expect(text).toContain('Handle Thing');
+        expect(text).toContain('async');
+      } finally {
+        await pair.teardown();
+      }
+    });
+  });
+});

--- a/src/tools/events/script-actions.ts
+++ b/src/tools/events/script-actions.ts
@@ -1,0 +1,254 @@
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import type { SnReference } from '../../types/servicenow.js';
+import {
+  handleError,
+  isSysId,
+  resolveDisplay,
+  resolveValue,
+} from '../helpers.js';
+import type { ToolRegistrar } from '../registry.js';
+import {
+  ScriptActionCreate,
+  ScriptActionList,
+  ScriptActionUpdate,
+} from './schemas.js';
+
+const TABLE = 'sysevent_script_action';
+
+type SnRecord = Record<string, SnReference | undefined>;
+
+const val = (r: SnRecord, f: string): string =>
+  r[f] ? resolveValue(r[f] as SnReference) : '';
+const disp = (r: SnRecord, f: string): string =>
+  r[f] ? resolveDisplay(r[f] as SnReference) : '';
+
+function recordUrl(client: ServiceNowClient, sysId: string): string {
+  return `${client.getInstanceUrl()}/${TABLE}.do?sys_id=${sysId}`;
+}
+
+export function registerScriptActionTools(
+  registry: ToolRegistrar,
+  client: ServiceNowClient,
+): void {
+  registry.registerTool(
+    'create_script_action',
+    {
+      access: 'write',
+      title: 'Create Script Action',
+      description: [
+        'Creates a script action (sysevent_script_action) — server-side JavaScript that',
+        'runs whenever a registered event is processed.',
+        '',
+        'event_name must match a registered event (sysevent_register). In the script the',
+        'fired event is the global `event` (event.parm1/parm2, event.instance = the',
+        'triggering record sys_id) and the related record is `current` when the event was',
+        'fired with one.',
+        '',
+        'IMPORTANT: `event` and `current` are NOT available in condition_script — put all',
+        'record-based conditions inside the script body, not the condition.',
+        '',
+        'Idempotent: if a script action with the same name on the same event already',
+        'exists, its sys_id is returned and no new record is created.',
+      ].join('\n'),
+      inputSchema: ScriptActionCreate,
+      annotations: {
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({
+      name,
+      event_name,
+      script,
+      condition_script,
+      order,
+      synchronous,
+      active,
+      description,
+    }) => {
+      try {
+        const existing = await client.listRecords<SnRecord>(
+          TABLE,
+          `name=${name}^event_name=${event_name}`,
+          ['sys_id'],
+          1,
+        );
+        if (existing.length > 0) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: [
+                  `Script action "${name}" on event "${event_name}" already exists — skipped.`,
+                  `sys_id: ${val(existing[0], 'sys_id')}`,
+                ].join('\n'),
+              },
+            ],
+          };
+        }
+
+        const body: Record<string, unknown> = {
+          name,
+          event_name,
+          script,
+          active: String(active),
+          synchronous: String(synchronous),
+        };
+        if (condition_script !== undefined)
+          body.condition_script = condition_script;
+        if (order !== undefined) body.order = String(order);
+        if (description !== undefined) body.description = description;
+
+        const record = await client.createRecord<SnRecord>(TABLE, body);
+        const sys_id = val(record, 'sys_id');
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: [
+                'Script action created.',
+                '',
+                `name:        ${name}`,
+                `event_name:  ${event_name}`,
+                `synchronous: ${synchronous}`,
+                `active:      ${active}`,
+                `sys_id:      ${sys_id}`,
+                `URL:         ${recordUrl(client, sys_id)}`,
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  registry.registerTool(
+    'update_script_action',
+    {
+      access: 'write',
+      title: 'Update Script Action',
+      description: [
+        'Updates fields on an existing sysevent_script_action record.',
+        'Pass only the fields you want to change — omitted fields are left unchanged.',
+      ].join('\n'),
+      inputSchema: ScriptActionUpdate,
+      annotations: {
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({
+      sys_id,
+      name,
+      event_name,
+      script,
+      condition_script,
+      order,
+      synchronous,
+      active,
+      description,
+    }) => {
+      try {
+        if (!isSysId(sys_id))
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `"${sys_id}" is not a valid sysevent_script_action sys_id.`,
+              },
+            ],
+            isError: true,
+          };
+
+        const body: Record<string, unknown> = {};
+        if (name !== undefined) body.name = name;
+        if (event_name !== undefined) body.event_name = event_name;
+        if (script !== undefined) body.script = script;
+        if (condition_script !== undefined)
+          body.condition_script = condition_script;
+        if (order !== undefined) body.order = String(order);
+        if (synchronous !== undefined) body.synchronous = String(synchronous);
+        if (active !== undefined) body.active = String(active);
+        if (description !== undefined) body.description = description;
+
+        if (Object.keys(body).length === 0) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'No fields to update — all values were omitted.',
+              },
+            ],
+          };
+        }
+
+        await client.patchRecord<unknown>(TABLE, sys_id, body);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: [
+                'Script action updated successfully.',
+                '',
+                `sys_id:         ${sys_id}`,
+                `Updated fields: ${Object.keys(body).join(', ')}`,
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  registry.registerTool(
+    'list_script_actions',
+    {
+      access: 'read',
+      title: 'List Script Actions',
+      description: [
+        'Lists script actions (sysevent_script_action), optionally filtered by the event',
+        'they listen on, name substring, or active state.',
+      ].join('\n'),
+      inputSchema: ScriptActionList,
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async ({ event_name, name_contains, active_only, limit }) => {
+      try {
+        const clauses: string[] = [];
+        if (event_name) clauses.push(`event_name=${event_name}`);
+        if (name_contains) clauses.push(`nameLIKE${name_contains}`);
+        if (active_only) clauses.push('active=true');
+        clauses.push('ORDERBYevent_name');
+
+        const rows = await client.listRecords<SnRecord>(
+          TABLE,
+          clauses.join('^'),
+          ['sys_id', 'name', 'event_name', 'active', 'order', 'synchronous'],
+          limit,
+        );
+
+        const summary = rows.length
+          ? rows
+              .map((r) => {
+                const active = val(r, 'active') === 'true';
+                const sync =
+                  val(r, 'synchronous') === 'true' ? 'sync' : 'async';
+                return `${disp(r, 'name')} — on ${val(r, 'event_name')} — ${sync}${active ? '' : ' (inactive)'} — ${val(r, 'sys_id')}`;
+              })
+              .join('\n')
+          : 'No script actions matched.';
+
+        return { content: [{ type: 'text' as const, text: summary }] };
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+}

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -86,6 +86,14 @@ describe('tool inventory', () => {
           "access": "write",
           "group": "scripts",
         },
+        "create_event_queue": {
+          "access": "write",
+          "group": "events",
+        },
+        "create_event_registration": {
+          "access": "write",
+          "group": "events",
+        },
         "create_fix_script": {
           "access": "write",
           "group": "diagnostics",
@@ -110,6 +118,10 @@ describe('tool inventory', () => {
           "access": "write",
           "group": "diagnostics",
         },
+        "create_script_action": {
+          "access": "write",
+          "group": "events",
+        },
         "create_script_include": {
           "access": "write",
           "group": "scripts",
@@ -130,6 +142,10 @@ describe('tool inventory', () => {
           "access": "read",
           "group": "catalog",
         },
+        "fire_event": {
+          "access": "write",
+          "group": "events",
+        },
         "get_atf_step_config_schema": {
           "access": "read",
           "group": "atf",
@@ -145,6 +161,10 @@ describe('tool inventory', () => {
         "get_current_update_set": {
           "access": "read",
           "group": "update-sets",
+        },
+        "get_event": {
+          "access": "read",
+          "group": "events",
         },
         "get_record": {
           "access": "read",
@@ -174,6 +194,14 @@ describe('tool inventory', () => {
           "access": "read",
           "group": "catalog",
         },
+        "list_event_queues": {
+          "access": "read",
+          "group": "events",
+        },
+        "list_events": {
+          "access": "read",
+          "group": "events",
+        },
         "list_flows": {
           "access": "read",
           "group": "catalog",
@@ -181,6 +209,10 @@ describe('tool inventory', () => {
         "list_scheduled_jobs": {
           "access": "read",
           "group": "diagnostics",
+        },
+        "list_script_actions": {
+          "access": "read",
+          "group": "events",
         },
         "list_update_sets": {
           "access": "read",
@@ -242,6 +274,14 @@ describe('tool inventory', () => {
           "access": "write",
           "group": "scripts",
         },
+        "update_event_queue": {
+          "access": "write",
+          "group": "events",
+        },
+        "update_event_registration": {
+          "access": "write",
+          "group": "events",
+        },
         "update_fix_script": {
           "access": "write",
           "group": "diagnostics",
@@ -265,6 +305,10 @@ describe('tool inventory', () => {
         "update_scheduled_script": {
           "access": "write",
           "group": "diagnostics",
+        },
+        "update_script_action": {
+          "access": "write",
+          "group": "events",
         },
         "update_script_include": {
           "access": "write",

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -34,6 +34,7 @@ export const TOOLSETS = [
   'atf',
   'catalog',
   'diagnostics',
+  'events',
   'records',
   'scripts',
   'update-sets',


### PR DESCRIPTION
## What this changes

Adds a new **`events`** tool domain (`src/tools/events/`) that exposes the ServiceNow event subsystem as MCP tools. Previously there was no way to register events, define processing queues, write script actions, or fire events at runtime.

**11 new tools:**

- **Event registrations** (`sysevent_register`) — `create_event_registration`, `update_event_registration`, `list_events`, `get_event` (rich two-block read showing the resolved queue + listening script actions)
- **Event queues** (`sysevent_queue`) — `create_event_queue`, `update_event_queue`, `list_event_queues`
- **Script actions** (`sysevent_script_action`) — `create_script_action`, `update_script_action`, `list_script_actions`
- **Runtime firing** — `fire_event`, which queues an event via `gs.eventQueue()` (optionally bound to a record) through a one-shot background script

Wired into `buildServer()` and registered `events` as a toolset in `TOOLSETS`. All Zod schemas were verified field-by-field against the live PDI dictionary (`sys_dictionary` / `sys_choice` / `sys_db_object`) — e.g. `sysevent_register` has no `active` field (idempotency keys on `event_name`), `sysevent_script_action` extends `Rule`, and `sysevent_queue.poll_interval` is a `glide_duration` epoch offset (exposed as `poll_interval_seconds`).

Closes #

## How it was verified

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test` passing (333 tests; 42 new across the 4 events files + updated inventory snapshot)
- [x] Exercised against a live ServiceNow PDI (for tool changes)

Live PDI run created a queue + registration + script action, confirmed `get_event` two-block output and idempotency skips, fired the event and verified it landed in `sysevent` routed to the custom queue with the correct `parm1` — then cleaned up the test records.

## Notes

- The `events` toolset is fail-open scoping only; write protection remains `X-MCP-Access`'s job (unchanged).
- `fire_event` is classified `write` (`destructiveHint: true`) since it mutates runtime state; the other writes are idempotent.
- No delete tool is included (consistent with the rest of the repo) — removing event config is out of scope.
- README updated: tool count 62 → 73, new Events feature row, toolset list, and an example prompt.
