### PR TITLE
feat: add UI action tools (sys_ui_action)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import { registerEventTools } from './tools/events/index.js';
 import { registerRecordTools } from './tools/records/index.js';
 import { ToolRegistry, type ToolRegistryOptions } from './tools/registry.js';
 import { registerScriptIncludesTools } from './tools/script-includes/index.js';
+import { registerUiActionsToolset } from './tools/ui-actions/index.js';
 import { registerUiPolicyToolset } from './tools/ui-policies/index.js';
 import { registerUpdateSetTools } from './tools/update-sets/index.js';
 
@@ -31,6 +32,7 @@ export function buildServer(
   registerRecordTools(registry, snClient);
   registerAtfTools(registry, snClient);
   registerEventTools(registry, snClient);
+  registerUiActionsToolset(registry, snClient);
   registerUiPolicyToolset(registry, snClient);
 
   return { server, registry };

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -138,6 +138,10 @@ describe('tool inventory', () => {
           "access": "write",
           "group": "script-includes",
         },
+        "create_ui_action": {
+          "access": "write",
+          "group": "ui-actions",
+        },
         "create_update_set": {
           "access": "write",
           "group": "update-sets",
@@ -190,6 +194,10 @@ describe('tool inventory', () => {
           "access": "read",
           "group": "diagnostics",
         },
+        "get_ui_action": {
+          "access": "read",
+          "group": "ui-actions",
+        },
         "list_atf_step_configs": {
           "access": "read",
           "group": "atf",
@@ -233,6 +241,10 @@ describe('tool inventory', () => {
         "list_script_actions": {
           "access": "read",
           "group": "events",
+        },
+        "list_ui_actions": {
+          "access": "read",
+          "group": "ui-actions",
         },
         "list_update_sets": {
           "access": "read",
@@ -345,6 +357,10 @@ describe('tool inventory', () => {
         "update_script_include": {
           "access": "write",
           "group": "script-includes",
+        },
+        "update_ui_action": {
+          "access": "write",
+          "group": "ui-actions",
         },
         "update_ui_policy": {
           "access": "write",

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -39,6 +39,7 @@ export const TOOLSETS = [
   'events',
   'records',
   'script-includes',
+  'ui-actions',
   'ui-policies',
   'update-sets',
 ] as const;

--- a/src/tools/ui-actions/index.ts
+++ b/src/tools/ui-actions/index.ts
@@ -1,0 +1,11 @@
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import type { ToolRegistry } from '../registry.js';
+import { registerUiActionTools } from './ui-actions.js';
+
+export function registerUiActionsToolset(
+  registry: ToolRegistry,
+  client: ServiceNowClient,
+): void {
+  const scoped = registry.scoped('ui-actions');
+  registerUiActionTools(scoped, client);
+}

--- a/src/tools/ui-actions/schemas.ts
+++ b/src/tools/ui-actions/schemas.ts
@@ -1,0 +1,292 @@
+import { z } from 'zod';
+
+// ── UI Action (sys_ui_action) ───────────────────────────────────────────────
+//
+// A single sys_ui_action record models a button / link / context-menu item on a
+// form or list, AND its Configurable-Workspace (Agent Workspace) equivalent —
+// the workspace fields live on the SAME record as the classic ones. The two
+// execution models are deliberately kept distinct in this schema so a caller
+// can't accidentally cross the wires:
+//
+//   • CLASSIC (platform UI): `script` (server-side) and/or `onclick` + `client`
+//     (client-side) with the full g_form / DOM / window API.
+//   • WORKSPACE (configurable workspace): `client_script_v2` — an onClick(g_form)
+//     function with the REDUCED workspace API (g_form, g_modal, GlideAjax; no
+//     DOM, no window globals) — gated behind format_for_configurable_workspace.
+//
+// Field shapes verified against the sys_ui_action dictionary on the PDI.
+
+const UiActionBase = z.object({
+  name: z
+    .string()
+    .min(1)
+    .max(40)
+    .describe(
+      'Label shown on the button / link / menu item, e.g. "Resolve Incident".',
+    ),
+  table: z
+    .string()
+    .min(1)
+    .describe(
+      "Internal name of the table the action appears on, e.g. 'incident' — " +
+        'NOT the label. Use resolve_table if unsure.',
+    ),
+  action_name: z
+    .string()
+    .max(40)
+    .optional()
+    .describe(
+      'Stable identifier for the action, used to invoke it from a client ' +
+        "script via gsftSubmit('<action_name>') and to read it server-side via " +
+        "current's action context. Optional but recommended when onclick calls " +
+        'gsftSubmit. Letters/underscores only — no spaces.',
+    ),
+  condition: z
+    .string()
+    .max(254)
+    .optional()
+    .describe(
+      'Server-side JavaScript boolean expression deciding whether the action ' +
+        'is shown for the current record. NOT an encoded query. Has access to ' +
+        '`current` and `gs`, e.g. "gs.hasRole(\'itil\')" or ' +
+        '"current.active == true". Leave empty to always show.',
+    ),
+  active: z.boolean().optional().describe('Whether the action is active.'),
+  order: z
+    .number()
+    .int()
+    .optional()
+    .describe(
+      'Display / execution order. Lower appears first (further left for ' +
+        'buttons). Default 100.',
+    ),
+  hint: z
+    .string()
+    .max(254)
+    .optional()
+    .describe('Tooltip text shown when hovering the button / link.'),
+  comments: z
+    .string()
+    .optional()
+    .describe(
+      'Free-text notes describing what the action does (not shown to users).',
+    ),
+
+  // ── Classic script model ─────────────────────────────────────────────────
+  client: z
+    .boolean()
+    .optional()
+    .describe(
+      'Run the action client-side. When true, the click invokes the function ' +
+        'named in `onclick`, defined in `script`. When false, `script` runs ' +
+        'server-side on click. Required true for the classic onclick path.',
+    ),
+  onclick: z
+    .string()
+    .max(254)
+    .optional()
+    .describe(
+      'CLASSIC client-side entry point: the name of the JS function (defined ' +
+        'in `script`) to call when clicked, e.g. "validateThenSubmit()". Only ' +
+        'used when client=true. This is the platform-UI onclick — NOT the ' +
+        'workspace script (use client_script_v2 for workspace).',
+    ),
+  script: z
+    .string()
+    .max(8000)
+    .optional()
+    .describe(
+      'CLASSIC script. When client=false this is the SERVER-side script run on ' +
+        'click, with access to `current`, `gs`, `previous`, and `action` ' +
+        '(e.g. action.setRedirectURL(url)); call current.update() to save. ' +
+        'When client=true this holds the client-side function definitions that ' +
+        '`onclick` calls, using the full g_form / window / DOM API; submit the ' +
+        "form with gsftSubmit(null, g_form.getFormElement(), '<action_name>') " +
+        'to also run the server script. This is the platform-UI script — NOT ' +
+        'the workspace script (use client_script_v2).',
+    ),
+  isolate_script: z
+    .boolean()
+    .optional()
+    .describe(
+      'Run the classic client script in an isolated scope with no access to ' +
+        'window / DOM globals. UI Actions often need globals, so this defaults ' +
+        'to false; set true only when the script is self-contained.',
+    ),
+  messages: z
+    .string()
+    .optional()
+    .describe(
+      'Newline-separated messages to pre-register for getMessage() lookups on ' +
+        'the client.',
+    ),
+
+  // ── Form placement (classic platform UI) ─────────────────────────────────
+  form_button: z
+    .boolean()
+    .optional()
+    .describe('Show as a button in the form header.'),
+  form_button_icon: z
+    .string()
+    .max(40)
+    .optional()
+    .describe('Optional icon for the form button.'),
+  form_link: z
+    .boolean()
+    .optional()
+    .describe('Show as a link under the form (related links).'),
+  form_context_menu: z
+    .boolean()
+    .optional()
+    .describe('Show in the form right-click context menu.'),
+
+  // ── List placement (classic platform UI) ─────────────────────────────────
+  list_button: z
+    .boolean()
+    .optional()
+    .describe('Show as a button at the bottom of the list.'),
+  list_button_icon: z
+    .string()
+    .max(40)
+    .optional()
+    .describe('Optional icon for the list button.'),
+  list_banner_button: z
+    .boolean()
+    .optional()
+    .describe('Show as a button in the list title banner (top of the list).'),
+  list_link: z
+    .boolean()
+    .optional()
+    .describe('Show as a link at the bottom of the list.'),
+  list_context_menu: z
+    .boolean()
+    .optional()
+    .describe('Show in the list row right-click context menu.'),
+  list_choice: z
+    .boolean()
+    .optional()
+    .describe(
+      'Show in the "Actions on selected rows" choice list (acts on checked rows).',
+    ),
+
+  // ── When the action is offered (classic) ─────────────────────────────────
+  show_insert: z
+    .boolean()
+    .optional()
+    .describe('Show on a new (not-yet-inserted) record. Default true.'),
+  show_update: z
+    .boolean()
+    .optional()
+    .describe('Show on an existing (already-inserted) record. Default true.'),
+  show_multiple_update: z
+    .boolean()
+    .optional()
+    .describe('Show on the multi-row list-edit screen.'),
+  show_query: z
+    .boolean()
+    .optional()
+    .describe('Show on a list query / filter context.'),
+
+  // ── Configurable Workspace (Agent Workspace) ─────────────────────────────
+  format_for_configurable_workspace: z
+    .boolean()
+    .optional()
+    .describe(
+      'MASTER TOGGLE for workspace. Must be true for ANY workspace flag below ' +
+        '(form_button_v2, form_menu_button_v2, client_script_v2) to take ' +
+        'effect — the #1 reason a workspace button never appears. This tool ' +
+        'auto-enables it when you set a workspace field, but you can set it ' +
+        'explicitly too.',
+    ),
+  form_button_v2: z
+    .boolean()
+    .optional()
+    .describe(
+      'Show as a button on the Configurable Workspace form. Requires ' +
+        'format_for_configurable_workspace=true (auto-enabled).',
+    ),
+  form_menu_button_v2: z
+    .boolean()
+    .optional()
+    .describe(
+      'Show in the Configurable Workspace form menu (the "..." overflow). ' +
+        'Requires format_for_configurable_workspace=true (auto-enabled).',
+    ),
+  client_script_v2: z
+    .string()
+    .max(8000)
+    .optional()
+    .describe(
+      'WORKSPACE client script — an onClick(g_form) function run in ' +
+        'Configurable Workspace. Uses the REDUCED workspace client API ' +
+        '(g_form, g_modal, GlideAjax) with NO DOM and NO window globals — do ' +
+        'NOT paste a classic onclick/script body here, it will fail. Requires ' +
+        'format_for_configurable_workspace=true (auto-enabled). Separate from ' +
+        'the classic `script` / `onclick`.',
+    ),
+});
+
+/**
+ * Every writable sys_ui_action column, derived from the base schema so the
+ * schema stays the single source of truth — the create/update handlers iterate
+ * this to build the request body instead of re-listing field names. sys_id is
+ * intentionally absent: it addresses the record, it is never written into it.
+ */
+export const UI_ACTION_FIELDS = Object.keys(UiActionBase.shape);
+
+export const UiActionCreate = UiActionBase.extend({
+  active: z.boolean().optional().default(true).describe('Defaults to true.'),
+  order: z.number().int().optional().default(100).describe('Defaults to 100.'),
+  client: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(
+      'Run the action client-side (invokes onclick). Defaults to false ' +
+        '(server-side script on click).',
+    ),
+  isolate_script: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(
+      'Isolate the classic client script from window / DOM globals. Defaults ' +
+        'to false (UI Actions commonly need globals).',
+    ),
+  // No default: an unspecified toggle is what lets the guardrail auto-enable
+  // it when a workspace field is set, while an explicit false is respected.
+});
+
+export const UiActionUpdate = UiActionBase.partial().extend({
+  sys_id: z
+    .string()
+    .min(1)
+    .describe('sys_id of the sys_ui_action record to update.'),
+});
+
+export const UiActionList = z.object({
+  table: z.string().optional().describe('Filter to actions on this table.'),
+  name_contains: z
+    .string()
+    .optional()
+    .describe('Filter to actions whose name contains this text.'),
+  active: z
+    .boolean()
+    .optional()
+    .describe('Filter by active flag. Omit to return both.'),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .default(50)
+    .describe('Maximum number of actions to return (1–100). Defaults to 50.'),
+});
+
+export const UiActionGet = z.object({
+  sys_id: z
+    .string()
+    .min(1)
+    .describe('sys_id of the sys_ui_action record to read.'),
+});

--- a/src/tools/ui-actions/ui-actions.test.ts
+++ b/src/tools/ui-actions/ui-actions.test.ts
@@ -1,0 +1,328 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import { SnApiError } from '../../clients/servicenow.js';
+import { buildTestPair, firstText } from '../../tests/helpers.js';
+import { registerUiActionTools } from './ui-actions.js';
+
+const EXISTING_SYS_ID = 'aaaa1111bbbb2222aaaa1111bbbb2222';
+const NEW_SYS_ID = 'dddd3333eeee4444dddd3333eeee4444';
+
+function ref(value: string) {
+  return { value, display_value: value };
+}
+
+function buildMockClient(): ServiceNowClient {
+  return {
+    listRecords: vi.fn().mockResolvedValue([]),
+    createRecord: vi.fn().mockResolvedValue({ sys_id: ref(NEW_SYS_ID) }),
+    patchRecord: vi.fn().mockResolvedValue({}),
+    getRecord: vi.fn().mockResolvedValue({ sys_id: ref(EXISTING_SYS_ID) }),
+    getInstanceUrl: vi.fn().mockReturnValue('https://pdi.example.com'),
+  } as unknown as ServiceNowClient;
+}
+
+describe('ui-action tools (in-memory MCP)', () => {
+  let mcpClient: Client;
+  let teardown: () => Promise<void>;
+  let mockClient: ServiceNowClient;
+
+  beforeEach(async () => {
+    mockClient = buildMockClient();
+    const pair = await buildTestPair(registerUiActionTools, mockClient);
+    mcpClient = pair.mcpClient;
+    teardown = pair.teardown;
+  });
+
+  afterEach(async () => {
+    await teardown();
+  });
+
+  describe('create_ui_action', () => {
+    it('creates a classic form button and returns its sys_id', async () => {
+      const result = await mcpClient.callTool({
+        name: 'create_ui_action',
+        arguments: {
+          name: 'Resolve',
+          table: 'incident',
+          form_button: true,
+          script: 'current.state = 6; current.update();',
+        },
+      });
+      const text = firstText(result);
+      expect(text).toContain('UI Action created');
+      expect(text).toContain(NEW_SYS_ID);
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('serialises booleans and order to strings', async () => {
+      await mcpClient.callTool({
+        name: 'create_ui_action',
+        arguments: {
+          name: 'My Action',
+          table: 'incident',
+          form_button: true,
+          client: true,
+          onclick: 'doIt()',
+        },
+      });
+      expect(mockClient.createRecord).toHaveBeenCalledWith(
+        'sys_ui_action',
+        expect.objectContaining({
+          name: 'My Action',
+          table: 'incident',
+          active: 'true',
+          order: '100',
+          client: 'true',
+          form_button: 'true',
+          onclick: 'doIt()',
+        }),
+      );
+      // Toggle left unspecified (no workspace field) → not sent at all.
+      const body = (mockClient.createRecord as ReturnType<typeof vi.fn>).mock
+        .calls[0][1];
+      expect(body).not.toHaveProperty('format_for_configurable_workspace');
+    });
+
+    it('auto-enables format_for_configurable_workspace when a workspace field is set', async () => {
+      const result = await mcpClient.callTool({
+        name: 'create_ui_action',
+        arguments: {
+          name: 'WS Button',
+          table: 'incident',
+          form_button_v2: true,
+          client_script_v2: 'function onClick(g_form) {}',
+        },
+      });
+      expect(mockClient.createRecord).toHaveBeenCalledWith(
+        'sys_ui_action',
+        expect.objectContaining({
+          form_button_v2: 'true',
+          format_for_configurable_workspace: 'true',
+        }),
+      );
+      const text = firstText(result);
+      expect(text).toContain('auto-enabled');
+      expect(text).toContain('workspace: enabled');
+    });
+
+    it('warns when no placement flag is set', async () => {
+      const result = await mcpClient.callTool({
+        name: 'create_ui_action',
+        arguments: {
+          name: 'Orphan',
+          table: 'incident',
+          script: 'gs.info("hi");',
+        },
+      });
+      expect(firstText(result)).toContain('no placement flag set');
+    });
+
+    it('returns existing record without creating when name+table exists', async () => {
+      const idempotent = {
+        ...buildMockClient(),
+        listRecords: vi
+          .fn()
+          .mockResolvedValue([{ sys_id: ref(EXISTING_SYS_ID) }]),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(registerUiActionTools, idempotent);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'create_ui_action',
+          arguments: { name: 'Resolve', table: 'incident', form_button: true },
+        });
+        const text = firstText(result);
+        expect(text).toContain('already exists');
+        expect(text).toContain(EXISTING_SYS_ID);
+        expect(idempotent.createRecord).not.toHaveBeenCalled();
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('surfaces SnApiError as isError with status in message', async () => {
+      const errorClient = {
+        ...buildMockClient(),
+        listRecords: vi
+          .fn()
+          .mockRejectedValue(
+            new SnApiError(500, 'Internal Server Error', 'fault', 'https://x'),
+          ),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(registerUiActionTools, errorClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'create_ui_action',
+          arguments: { name: 'X', table: 'incident', form_button: true },
+        });
+        expect(result.isError).toBe(true);
+        expect(firstText(result)).toContain('500');
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('rejects empty name with a validation error', async () => {
+      const result = await mcpClient.callTool({
+        name: 'create_ui_action',
+        arguments: { name: '', table: 'incident' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('update_ui_action', () => {
+    it('patches the record and lists updated fields', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_ui_action',
+        arguments: { sys_id: EXISTING_SYS_ID, name: 'Renamed', active: false },
+      });
+      const text = firstText(result);
+      expect(text).toContain('updated successfully');
+      expect(mockClient.patchRecord).toHaveBeenCalledWith(
+        'sys_ui_action',
+        EXISTING_SYS_ID,
+        expect.objectContaining({ name: 'Renamed', active: 'false' }),
+      );
+    });
+
+    it('auto-enables workspace toggle on update when a workspace field is set', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_ui_action',
+        arguments: { sys_id: EXISTING_SYS_ID, form_menu_button_v2: true },
+      });
+      expect(mockClient.patchRecord).toHaveBeenCalledWith(
+        'sys_ui_action',
+        EXISTING_SYS_ID,
+        expect.objectContaining({
+          form_menu_button_v2: 'true',
+          format_for_configurable_workspace: 'true',
+        }),
+      );
+      expect(firstText(result)).toContain('auto-enabled');
+    });
+
+    it('does not auto-enable when workspace toggle is explicitly false', async () => {
+      await mcpClient.callTool({
+        name: 'update_ui_action',
+        arguments: {
+          sys_id: EXISTING_SYS_ID,
+          form_button_v2: true,
+          format_for_configurable_workspace: false,
+        },
+      });
+      expect(mockClient.patchRecord).toHaveBeenCalledWith(
+        'sys_ui_action',
+        EXISTING_SYS_ID,
+        expect.objectContaining({
+          form_button_v2: 'true',
+          format_for_configurable_workspace: 'false',
+        }),
+      );
+    });
+
+    it('returns isError when sys_id is not a valid hex id', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_ui_action',
+        arguments: { sys_id: 'not-valid', name: 'x' },
+      });
+      expect(result.isError).toBe(true);
+      expect(firstText(result)).toContain('not a valid');
+    });
+
+    it('returns no-op when no fields besides sys_id are provided', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_ui_action',
+        arguments: { sys_id: EXISTING_SYS_ID },
+      });
+      expect(firstText(result)).toContain('No fields to update');
+    });
+  });
+
+  describe('list_ui_actions', () => {
+    it('summarises matched actions with flags', async () => {
+      const listClient = {
+        ...buildMockClient(),
+        listRecords: vi.fn().mockResolvedValue([
+          {
+            sys_id: ref(NEW_SYS_ID),
+            name: ref('Resolve'),
+            table: ref('incident'),
+            active: ref('true'),
+            order: ref('100'),
+            client: ref('true'),
+            format_for_configurable_workspace: ref('true'),
+          },
+        ]),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(registerUiActionTools, listClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'list_ui_actions',
+          arguments: { table: 'incident' },
+        });
+        const text = firstText(result);
+        expect(text).toContain('Resolve');
+        expect(text).toContain('client');
+        expect(text).toContain('workspace');
+      } finally {
+        await pair.teardown();
+      }
+    });
+  });
+
+  describe('get_ui_action', () => {
+    it('returns a rich result with decoded placement and view restrictions', async () => {
+      const getClient = {
+        ...buildMockClient(),
+        getRecord: vi.fn().mockResolvedValue({
+          sys_id: ref(EXISTING_SYS_ID),
+          name: ref('Resolve'),
+          table: ref('incident'),
+          active: ref('true'),
+          order: ref('100'),
+          condition: ref("gs.hasRole('itil')"),
+          client: ref('false'),
+          form_button: ref('true'),
+          show_insert: ref('true'),
+          show_update: ref('true'),
+          format_for_configurable_workspace: ref('true'),
+          form_button_v2: ref('true'),
+          client_script_v2: ref('function onClick(g_form) {}'),
+        }),
+        listRecords: vi.fn().mockResolvedValue([
+          {
+            sys_id: ref('v1'),
+            sys_ui_view: ref('Mobile'),
+            visibility: ref('include'),
+          },
+        ]),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(registerUiActionTools, getClient);
+      try {
+        const result = (await pair.mcpClient.callTool({
+          name: 'get_ui_action',
+          arguments: { sys_id: EXISTING_SYS_ID },
+        })) as { content: Array<{ text: string }> };
+        const summary = result.content[0].text;
+        expect(summary).toContain('UI Action: Resolve');
+        expect(summary).toContain('Form:      button');
+        expect(summary).toContain('Workspace: enabled');
+        expect(summary).toContain('Mobile (include)');
+        const json = JSON.parse(result.content[1].text);
+        expect(json.workspace.enabled).toBe(true);
+        expect(json.view_restrictions).toHaveLength(1);
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('returns isError for an invalid sys_id', async () => {
+      const result = await mcpClient.callTool({
+        name: 'get_ui_action',
+        arguments: { sys_id: 'bad' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+});

--- a/src/tools/ui-actions/ui-actions.ts
+++ b/src/tools/ui-actions/ui-actions.ts
@@ -1,0 +1,421 @@
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import type { SnRecord, SnReference } from '../../types/servicenow.js';
+import {
+  disp,
+  errText,
+  handleError,
+  recordUrl,
+  requireSysId,
+  resolveValue,
+  richResult,
+  textResult,
+  val,
+} from '../helpers.js';
+import type { ToolRegistrar } from '../registry.js';
+import {
+  UI_ACTION_FIELDS,
+  UiActionCreate,
+  UiActionGet,
+  UiActionList,
+  UiActionUpdate,
+} from './schemas.js';
+
+const TABLE = 'sys_ui_action';
+const VIEW_TABLE = 'sys_ui_action_view';
+
+// Single source of truth for placement: each flag paired with the label used
+// in read output, grouped by surface. The placement warning (create/update),
+// the workspace guardrail, and the get decode all derive from this — no field
+// name is repeated elsewhere.
+const PLACEMENT = {
+  form: [
+    ['form_button', 'button'],
+    ['form_link', 'link'],
+    ['form_context_menu', 'context menu'],
+  ],
+  list: [
+    ['list_button', 'bottom button'],
+    ['list_banner_button', 'banner button'],
+    ['list_link', 'link'],
+    ['list_context_menu', 'context menu'],
+    ['list_choice', 'choice list'],
+  ],
+  workspace: [
+    ['form_button_v2', 'form button'],
+    ['form_menu_button_v2', 'form menu'],
+  ],
+} as const satisfies Record<string, readonly (readonly [string, string])[]>;
+
+// At least one placement flag must be set or the action appears nowhere.
+const PLACEMENT_FIELDS = Object.values(PLACEMENT).flatMap((group) =>
+  group.map(([field]) => field),
+);
+
+const WORKSPACE_AUTOENABLE_NOTE =
+  'NOTE: format_for_configurable_workspace was auto-enabled because a ' +
+  'workspace field was set.';
+
+type UiActionInput = Record<string, unknown>;
+
+/**
+ * Workspace fields do nothing unless format_for_configurable_workspace is true.
+ * Returns whether any workspace field was requested and whether the master
+ * toggle had to be auto-enabled as a result.
+ */
+function resolveWorkspaceToggle(input: UiActionInput): {
+  wantsWorkspace: boolean;
+  autoEnabled: boolean;
+  toggle: boolean | undefined;
+} {
+  const scriptV2 = input.client_script_v2;
+  const wantsWorkspace =
+    PLACEMENT.workspace.some(([field]) => input[field] === true) ||
+    (typeof scriptV2 === 'string' && scriptV2.trim() !== '');
+
+  let toggle = input.format_for_configurable_workspace as boolean | undefined;
+  let autoEnabled = false;
+  // Only force the toggle on when the caller left it unspecified — an explicit
+  // false is the caller's choice and is respected.
+  if (wantsWorkspace && toggle === undefined) {
+    toggle = true;
+    autoEnabled = true;
+  }
+  return { wantsWorkspace, autoEnabled, toggle };
+}
+
+/** Builds the Table API body from the supplied (already-defaulted) input. */
+function buildBody(
+  input: UiActionInput,
+  toggle: boolean | undefined,
+): UiActionInput {
+  const body: UiActionInput = {};
+  for (const f of UI_ACTION_FIELDS) {
+    const v = input[f];
+    if (v === undefined) continue;
+    // The Table API takes strings; booleans and the numeric order serialise.
+    body[f] = typeof v === 'string' ? v : String(v);
+  }
+  // The toggle may have been forced on by the workspace guardrail.
+  if (toggle !== undefined)
+    body.format_for_configurable_workspace = String(toggle);
+  return body;
+}
+
+function placementWarning(input: UiActionInput): string | null {
+  const hasPlacement = PLACEMENT_FIELDS.some((f) => input[f] === true);
+  return hasPlacement
+    ? null
+    : 'WARNING: no placement flag set (form_button, form_link, list_button, ' +
+        'form_button_v2, …) — the action will not appear anywhere until one is set.';
+}
+
+export function registerUiActionTools(
+  registry: ToolRegistrar,
+  client: ServiceNowClient,
+): void {
+  registry.registerTool(
+    'create_ui_action',
+    {
+      access: 'write',
+      title: 'Create UI Action',
+      description: [
+        'Creates a sys_ui_action record — a button, link, or context-menu item',
+        'on a ServiceNow form or list, optionally also in Configurable Workspace.',
+        '',
+        'TWO execution models on the same record, kept distinct:',
+        '• CLASSIC (platform UI): server-side `script` (client=false), or a',
+        '  client function named by `onclick` defined in `script` (client=true) —',
+        '  full g_form / DOM API.',
+        '• WORKSPACE (Agent Workspace): `client_script_v2` onClick(g_form) with the',
+        '  reduced workspace API. Never paste a classic script into client_script_v2.',
+        '',
+        'GUARDRAIL: setting any workspace field (form_button_v2, form_menu_button_v2,',
+        'client_script_v2) auto-enables format_for_configurable_workspace — without',
+        'it the workspace button silently never appears.',
+        '',
+        'Set at least one placement flag (form_button, list_button, …) or the action',
+        'appears nowhere. Idempotent: an existing action with the same name+table is',
+        'returned unchanged.',
+      ].join('\n'),
+      inputSchema: UiActionCreate,
+      annotations: {
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (input) => {
+      try {
+        const { name, table } = input;
+        const existing = await client.listRecords<{ sys_id: SnReference }>(
+          TABLE,
+          `name=${name}^table=${table}`,
+          ['sys_id'],
+          1,
+        );
+        if (existing.length > 0) {
+          return textResult(
+            [
+              'UI Action already exists — skipped.',
+              '',
+              `name:   ${name}`,
+              `table:  ${table}`,
+              `sys_id: ${resolveValue(existing[0].sys_id)}`,
+            ].join('\n'),
+          );
+        }
+
+        const { wantsWorkspace, autoEnabled, toggle } =
+          resolveWorkspaceToggle(input);
+        const body = buildBody(input, toggle);
+
+        const record = await client.createRecord<SnRecord>(TABLE, body);
+        const sys_id = val(record, 'sys_id');
+
+        const lines = [
+          'UI Action created.',
+          '',
+          `name:      ${name}`,
+          `table:     ${table}`,
+          `client:    ${input.client === true}`,
+          `workspace: ${wantsWorkspace ? 'enabled' : 'no'}`,
+          `order:     ${input.order ?? 100}`,
+          `sys_id:    ${sys_id}`,
+          `URL:       ${recordUrl(client, TABLE, sys_id)}`,
+        ];
+        if (autoEnabled) lines.push('', WORKSPACE_AUTOENABLE_NOTE);
+        const warn = placementWarning(input);
+        if (warn) lines.push('', warn);
+
+        return textResult(lines.join('\n'));
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  registry.registerTool(
+    'update_ui_action',
+    {
+      access: 'write',
+      title: 'Update UI Action',
+      description: [
+        'Updates fields on an existing sys_ui_action record.',
+        'Pass only the fields you want to change — omitted fields stay as-is.',
+        '',
+        'GUARDRAIL: setting a workspace field (form_button_v2, form_menu_button_v2,',
+        'client_script_v2) auto-enables format_for_configurable_workspace unless you',
+        'explicitly pass it as false.',
+      ].join('\n'),
+      inputSchema: UiActionUpdate,
+      annotations: {
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (input) => {
+      try {
+        const sys_id = input.sys_id as string;
+        const idErr = requireSysId(sys_id, 'sys_ui_action sys_id');
+        if (idErr) return errText(idErr);
+
+        const { autoEnabled, toggle } = resolveWorkspaceToggle(input);
+        const body = buildBody(input, toggle);
+
+        if (Object.keys(body).length === 0) {
+          return textResult('No fields to update — all values were omitted.');
+        }
+
+        await client.patchRecord<unknown>(TABLE, sys_id, body);
+
+        const lines = [
+          'UI Action updated successfully.',
+          '',
+          `sys_id:         ${sys_id}`,
+          `Updated fields: ${Object.keys(body).join(', ')}`,
+        ];
+        if (autoEnabled) lines.push('', WORKSPACE_AUTOENABLE_NOTE);
+        return textResult(lines.join('\n'));
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  registry.registerTool(
+    'list_ui_actions',
+    {
+      access: 'read',
+      title: 'List UI Actions',
+      description: [
+        'Lists sys_ui_action records, optionally filtered by table, name',
+        'substring, or active flag. Ordered by table then order.',
+      ].join('\n'),
+      inputSchema: UiActionList,
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async ({ table, name_contains, active, limit }) => {
+      try {
+        const clauses: string[] = [];
+        if (table) clauses.push(`table=${table}`);
+        if (name_contains) clauses.push(`nameLIKE${name_contains}`);
+        if (active !== undefined) clauses.push(`active=${String(active)}`);
+        clauses.push('ORDERBYtable', 'ORDERBYorder');
+
+        const rows = await client.listRecords<SnRecord>(
+          TABLE,
+          clauses.join('^'),
+          [
+            'sys_id',
+            'name',
+            'table',
+            'active',
+            'order',
+            'client',
+            'form_button',
+            'list_button',
+            'format_for_configurable_workspace',
+          ],
+          limit,
+        );
+
+        const summary = rows.length
+          ? rows
+              .map((r) => {
+                const flags: string[] = [];
+                if (val(r, 'client') === 'true') flags.push('client');
+                if (val(r, 'format_for_configurable_workspace') === 'true')
+                  flags.push('workspace');
+                const tag = flags.length ? ` [${flags.join(', ')}]` : '';
+                const act = val(r, 'active') === 'true' ? '' : ' (inactive)';
+                return (
+                  `${disp(r, 'table')} — ${val(r, 'name')}${act} ` +
+                  `— order ${val(r, 'order') || '100'}${tag} — ${val(r, 'sys_id')}`
+                );
+              })
+              .join('\n')
+          : 'No UI actions matched.';
+
+        return textResult(summary);
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  registry.registerTool(
+    'get_ui_action',
+    {
+      access: 'read',
+      title: 'Get UI Action',
+      description: [
+        'Reads a single sys_ui_action record: its classic placement / script,',
+        'its Configurable Workspace configuration, and any per-view visibility',
+        'restrictions (sys_ui_action_view, read-only here).',
+      ].join('\n'),
+      inputSchema: UiActionGet,
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async ({ sys_id }) => {
+      try {
+        const idErr = requireSysId(sys_id, 'sys_ui_action sys_id');
+        if (idErr) return errText(idErr);
+
+        // Independent reads — the view query keys off the input sys_id.
+        const [base, viewRows] = await Promise.all([
+          client.getRecord<SnRecord>(TABLE, sys_id),
+          client.listRecords<SnRecord>(
+            VIEW_TABLE,
+            `sys_ui_action=${sys_id}`,
+            ['sys_id', 'sys_ui_view', 'visibility'],
+            50,
+          ),
+        ]);
+
+        const bool = (f: string) => val(base, f) === 'true';
+        // Labels for the placement flags that are set on, derived from PLACEMENT.
+        const placedLabels = (
+          group: (typeof PLACEMENT)[keyof typeof PLACEMENT],
+        ) => group.filter(([field]) => bool(field)).map(([, label]) => label);
+
+        const formPlacement = placedLabels(PLACEMENT.form);
+        const listPlacement = placedLabels(PLACEMENT.list);
+        const workspacePlacement = placedLabels(PLACEMENT.workspace);
+
+        const viewRestrictions = viewRows.map((v) => ({
+          sys_id: val(v, 'sys_id'),
+          view: disp(v, 'sys_ui_view'),
+          visibility: val(v, 'visibility'),
+        }));
+
+        const result = {
+          sys_id: val(base, 'sys_id'),
+          name: val(base, 'name'),
+          table: disp(base, 'table'),
+          action_name: val(base, 'action_name'),
+          active: bool('active'),
+          order: val(base, 'order') || '100',
+          condition: val(base, 'condition'),
+          hint: val(base, 'hint'),
+          comments: val(base, 'comments'),
+          client: bool('client'),
+          isolate_script: bool('isolate_script'),
+          onclick: val(base, 'onclick'),
+          script: val(base, 'script'),
+          show: {
+            insert: bool('show_insert'),
+            update: bool('show_update'),
+            multiple_update: bool('show_multiple_update'),
+            query: bool('show_query'),
+          },
+          form_placement: formPlacement,
+          list_placement: listPlacement,
+          workspace: {
+            enabled: bool('format_for_configurable_workspace'),
+            placement: workspacePlacement,
+            client_script_v2: val(base, 'client_script_v2'),
+          },
+          view_restrictions: viewRestrictions,
+          url: recordUrl(client, TABLE, sys_id),
+        };
+
+        const summary = [
+          `UI Action: ${result.name} (${result.sys_id})`,
+          `Table:     ${result.table}${result.active ? '' : ' — INACTIVE'}`,
+          `Condition: ${result.condition || '(always)'}`,
+          `Order:     ${result.order} · client=${result.client} · action_name=${
+            result.action_name || '—'
+          }`,
+          `Shows on:  ${
+            Object.entries(result.show)
+              .filter(([, on]) => on)
+              .map(([k]) => k)
+              .join(', ') || '(none)'
+          }`,
+          `Form:      ${result.form_placement.join(', ') || '(none)'}`,
+          `List:      ${result.list_placement.join(', ') || '(none)'}`,
+          `Workspace: ${
+            result.workspace.enabled
+              ? `enabled — ${
+                  result.workspace.placement.join(', ') || 'no placement'
+                }${result.workspace.client_script_v2 ? ' · has client_script_v2' : ''}`
+              : 'disabled'
+          }`,
+          `Views:     ${
+            viewRestrictions.length
+              ? viewRestrictions
+                  .map((v) => `${v.view} (${v.visibility})`)
+                  .join(', ')
+              : '(all views)'
+          }`,
+          `URL:       ${result.url}`,
+        ].join('\n');
+
+        return richResult(summary, result);
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+}


### PR DESCRIPTION
## What this changes

Adds a ui-actions toolset for managing sys_ui_action records (form/list buttons, links, context menus) over the ServiceNow Table API. Four tools:

create_ui_action / update_ui_action — write tools covering classic placement and Configurable Workspace, with two safety behaviors: auto-enabling the workspace master toggle (format_for_configurable_workspace) when a workspace field is set, and warning when no placement flag is set (the action would be invisible).
list_ui_actions — filter by table, name substring, or active flag.
get_ui_action — rich read of a single action (classic script/placement, workspace config, per-view restrictions).
Wired into buildServer() and the tool registry.

## How it was verified

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test` passing
- [x] Exercised against a live ServiceNow PDI (for tool changes)

## Notes

action_name collisions are a known footgun. gsftSubmit routes the server-side run by action_name, not sys_id — so two actions on the same table sharing an action_name will submit to each other's server script (e.g. the OOB close_sc_task on sc_task). The tools do not yet guard against this; a collision warning at create/update time is a sensible follow-up.
New domain folder is self-contained (index.ts, schemas.ts, tool file, colocated test) and imports only helpers.ts, per the architecture rules.
