### PR TITLE
feat: add inbound email action tools (sysevent_in_email_action)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import { registerCatalogTools } from './tools/catalog/index.js';
 import { registerClientScriptsTools } from './tools/client-scripts/index.js';
 import { registerDiagnosticsTools } from './tools/diagnostics/index.js';
 import { registerEventTools } from './tools/events/index.js';
+import { registerInboundActionsToolset } from './tools/inbound-actions/index.js';
 import { registerRecordTools } from './tools/records/index.js';
 import { ToolRegistry, type ToolRegistryOptions } from './tools/registry.js';
 import { registerScriptIncludesTools } from './tools/script-includes/index.js';
@@ -32,6 +33,7 @@ export function buildServer(
   registerRecordTools(registry, snClient);
   registerAtfTools(registry, snClient);
   registerEventTools(registry, snClient);
+  registerInboundActionsToolset(registry, snClient);
   registerUiActionsToolset(registry, snClient);
   registerUiPolicyToolset(registry, snClient);
 

--- a/src/tools/helpers.ts
+++ b/src/tools/helpers.ts
@@ -59,6 +59,26 @@ export function requireSysId(value: string, label: string): string | null {
   return isSysId(value) ? null : `"${value}" is not a valid ${label}.`;
 }
 
+/**
+ * Builds a Table API request body from a tool's input: for each field name in
+ * `fields`, copies the value through when it is defined, serialising booleans
+ * and numbers to the strings the Table API expects (strings pass through
+ * untouched). `fields` is typically `Object.keys(SomeBase.shape)` so the Zod
+ * schema stays the single source of truth for the column list.
+ */
+export function serializeFields(
+  input: Record<string, unknown>,
+  fields: readonly string[],
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  for (const f of fields) {
+    const v = input[f];
+    if (v === undefined) continue;
+    body[f] = typeof v === 'string' ? v : String(v);
+  }
+  return body;
+}
+
 export function handleError(err: unknown) {
   if (err instanceof SnApiError) {
     return {

--- a/src/tools/inbound-actions/inbound-actions.test.ts
+++ b/src/tools/inbound-actions/inbound-actions.test.ts
@@ -1,0 +1,290 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import { SnApiError } from '../../clients/servicenow.js';
+import { buildTestPair, firstText } from '../../tests/helpers.js';
+import { registerInboundActionTools } from './inbound-actions.js';
+
+const EXISTING_SYS_ID = 'aaaa1111bbbb2222aaaa1111bbbb2222';
+const NEW_SYS_ID = 'cccc3333dddd4444cccc3333dddd4444';
+
+function buildMockClient(): ServiceNowClient {
+  return {
+    listRecords: vi.fn().mockResolvedValue([]),
+    createRecord: vi.fn().mockResolvedValue({
+      sys_id: { value: NEW_SYS_ID, display_value: NEW_SYS_ID },
+    }),
+    patchRecord: vi.fn().mockResolvedValue({}),
+    getRecord: vi.fn().mockResolvedValue({
+      sys_id: { value: EXISTING_SYS_ID, display_value: EXISTING_SYS_ID },
+      name: { value: 'Create Incident', display_value: 'Create Incident' },
+      type: { value: 'new', display_value: 'New' },
+      action: { value: 'record_action', display_value: 'Record Action' },
+      table: { value: 'incident', display_value: 'incident' },
+      active: { value: 'true', display_value: 'true' },
+      order: { value: '100', display_value: '100' },
+      stop_processing: { value: 'false', display_value: 'false' },
+      event_name: { value: 'email.read', display_value: 'email.read' },
+      from: { value: '', display_value: '' },
+      filter_condition: { value: '', display_value: '' },
+      condition_script: { value: '', display_value: '' },
+      script: {
+        value: 'current.insert();',
+        display_value: 'current.insert();',
+      },
+      reply_email: { value: '', display_value: '' },
+      description: { value: '', display_value: '' },
+      required_roles: { value: '', display_value: '' },
+    }),
+    getInstanceUrl: vi.fn().mockReturnValue('https://pdi.service-now.com'),
+  } as unknown as ServiceNowClient;
+}
+
+describe('inbound-action tools (in-memory MCP)', () => {
+  let mcpClient: Client;
+  let teardown: () => Promise<void>;
+
+  beforeEach(async () => {
+    const pair = await buildTestPair(
+      registerInboundActionTools,
+      buildMockClient(),
+    );
+    mcpClient = pair.mcpClient;
+    teardown = pair.teardown;
+  });
+
+  afterEach(async () => {
+    await teardown();
+  });
+
+  describe('create_inbound_action', () => {
+    it('creates a New action and returns its sys_id', async () => {
+      const result = await mcpClient.callTool({
+        name: 'create_inbound_action',
+        arguments: {
+          name: 'Create Incident',
+          type: 'new',
+          table: 'incident',
+          script:
+            'current.short_description = email.subject; current.insert();',
+        },
+      });
+      const text = firstText(result);
+      expect(text).toContain('created');
+      expect(text).toContain(NEW_SYS_ID);
+      expect(text).toContain('Create Incident');
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('serialises booleans/numbers to strings and applies defaults', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerInboundActionTools, mockClient);
+      try {
+        await pair.mcpClient.callTool({
+          name: 'create_inbound_action',
+          arguments: { name: 'My Action', type: 'new', table: 'incident' },
+        });
+        expect(mockClient.createRecord).toHaveBeenCalledWith(
+          'sysevent_in_email_action',
+          expect.objectContaining({
+            name: 'My Action',
+            type: 'new',
+            action: 'record_action',
+            table: 'incident',
+            active: 'true',
+            order: '100',
+            stop_processing: 'false',
+          }),
+        );
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('GUARDRAIL: rejects type=new without a target table', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerInboundActionTools, mockClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'create_inbound_action',
+          arguments: { name: 'Missing Table', type: 'new' },
+        });
+        expect(result.isError).toBe(true);
+        expect(firstText(result)).toContain('type=new requires');
+        expect(mockClient.createRecord).not.toHaveBeenCalled();
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('creates a Reply action without requiring a table', async () => {
+      const result = await mcpClient.callTool({
+        name: 'create_inbound_action',
+        arguments: {
+          name: 'Update Incident',
+          type: 'reply',
+          script: 'current.comments = email.body_text; current.update();',
+        },
+      });
+      const text = firstText(result);
+      expect(text).toContain('created');
+      expect(text).toContain('reply');
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('warns when action=reply_email but no reply body is set', async () => {
+      const result = await mcpClient.callTool({
+        name: 'create_inbound_action',
+        arguments: {
+          name: 'Auto Reply',
+          type: 'reply',
+          action: 'reply_email',
+        },
+      });
+      const text = firstText(result);
+      expect(text).toContain('WARNING');
+      expect(text).toContain('reply_email');
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('returns existing record without creating when name+table already exists', async () => {
+      const idempotentClient = {
+        ...buildMockClient(),
+        listRecords: vi.fn().mockResolvedValue([
+          {
+            sys_id: {
+              value: EXISTING_SYS_ID,
+              display_value: EXISTING_SYS_ID,
+            },
+          },
+        ]),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(
+        registerInboundActionTools,
+        idempotentClient,
+      );
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'create_inbound_action',
+          arguments: {
+            name: 'Create Incident',
+            type: 'new',
+            table: 'incident',
+          },
+        });
+        const text = firstText(result);
+        expect(text).toContain('already exists');
+        expect(text).toContain(EXISTING_SYS_ID);
+        expect(idempotentClient.createRecord).not.toHaveBeenCalled();
+        expect(result.isError).toBeFalsy();
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('surfaces SnApiError as isError with status in message', async () => {
+      const errorClient = {
+        ...buildMockClient(),
+        listRecords: vi
+          .fn()
+          .mockRejectedValue(
+            new SnApiError(500, 'Internal Server Error', 'fault', 'https://x'),
+          ),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(registerInboundActionTools, errorClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'create_inbound_action',
+          arguments: { name: 'X', type: 'new', table: 'incident' },
+        });
+        expect(result.isError).toBe(true);
+        expect(firstText(result)).toContain('500');
+      } finally {
+        await pair.teardown();
+      }
+    });
+  });
+
+  describe('update_inbound_action', () => {
+    it('patches the record and lists updated fields', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_inbound_action',
+        arguments: { sys_id: EXISTING_SYS_ID, active: false, order: 50 },
+      });
+      const text = firstText(result);
+      expect(text).toContain('updated successfully');
+      expect(text).toContain(EXISTING_SYS_ID);
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('serialises the boolean to a string', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerInboundActionTools, mockClient);
+      try {
+        await pair.mcpClient.callTool({
+          name: 'update_inbound_action',
+          arguments: { sys_id: EXISTING_SYS_ID, stop_processing: true },
+        });
+        expect(mockClient.patchRecord).toHaveBeenCalledWith(
+          'sysevent_in_email_action',
+          EXISTING_SYS_ID,
+          expect.objectContaining({ stop_processing: 'true' }),
+        );
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('returns isError when sys_id is not a valid hex id', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_inbound_action',
+        arguments: { sys_id: 'not-valid', name: 'x' },
+      });
+      expect(result.isError).toBe(true);
+      expect(firstText(result)).toContain('not a valid');
+    });
+
+    it('returns no-op message when only sys_id is provided', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_inbound_action',
+        arguments: { sys_id: EXISTING_SYS_ID },
+      });
+      expect(firstText(result)).toContain('No fields to update');
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  describe('list_inbound_actions', () => {
+    it('returns a no-match message when nothing matches', async () => {
+      const result = await mcpClient.callTool({
+        name: 'list_inbound_actions',
+        arguments: { table: 'incident' },
+      });
+      expect(firstText(result)).toContain('No inbound email actions matched');
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  describe('get_inbound_action', () => {
+    it('returns a two-block rich result with summary then JSON', async () => {
+      const result = (await mcpClient.callTool({
+        name: 'get_inbound_action',
+        arguments: { sys_id: EXISTING_SYS_ID },
+      })) as { content: Array<{ type: string; text: string }> };
+      expect(result.content).toHaveLength(2);
+      expect(result.content[0].text).toContain('Inbound Email Action');
+      const parsed = JSON.parse(result.content[1].text);
+      expect(parsed.sys_id).toBe(EXISTING_SYS_ID);
+      expect(parsed.type).toBe('new');
+      expect(parsed.active).toBe(true);
+    });
+
+    it('returns isError when sys_id is not a valid hex id', async () => {
+      const result = await mcpClient.callTool({
+        name: 'get_inbound_action',
+        arguments: { sys_id: 'nope' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+});

--- a/src/tools/inbound-actions/inbound-actions.ts
+++ b/src/tools/inbound-actions/inbound-actions.ts
@@ -1,0 +1,327 @@
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import type { SnRecord, SnReference } from '../../types/servicenow.js';
+import {
+  disp,
+  errText,
+  handleError,
+  recordUrl,
+  requireSysId,
+  resolveValue,
+  richResult,
+  textResult,
+  val,
+} from '../helpers.js';
+import type { ToolRegistrar } from '../registry.js';
+import {
+  INBOUND_ACTION_FIELDS,
+  InboundActionCreate,
+  InboundActionGet,
+  InboundActionList,
+  InboundActionUpdate,
+} from './schemas.js';
+
+const TABLE = 'sysevent_in_email_action';
+
+type InboundActionInput = Record<string, unknown>;
+
+/** Builds the Table API body from the supplied (already-defaulted) input. */
+function buildBody(input: InboundActionInput): InboundActionInput {
+  const body: InboundActionInput = {};
+  for (const f of INBOUND_ACTION_FIELDS) {
+    const v = input[f];
+    if (v === undefined) continue;
+    // The Table API takes strings; booleans and the numeric order serialise.
+    body[f] = typeof v === 'string' ? v : String(v);
+  }
+  return body;
+}
+
+/**
+ * Type-specific guardrails shared by create and update. Returns the warning
+ * lines to append to the result (empty when nothing to flag).
+ */
+function guardrails(input: InboundActionInput): string[] {
+  const warnings: string[] = [];
+  if (
+    input.action === 'reply_email' &&
+    (input.reply_email === undefined || input.reply_email === '')
+  ) {
+    warnings.push(
+      'WARNING: action=reply_email but no reply_email body was set — the sender ' +
+        'will receive an empty reply.',
+    );
+  }
+  return warnings;
+}
+
+export function registerInboundActionTools(
+  registry: ToolRegistrar,
+  client: ServiceNowClient,
+): void {
+  registry.registerTool(
+    'create_inbound_action',
+    {
+      access: 'write',
+      title: 'Create Inbound Email Action',
+      description: [
+        'Creates a sysevent_in_email_action record — server-side logic that runs',
+        'when ServiceNow receives an email.',
+        '',
+        'PROCESSING ORDER: incoming email is classified as New / Reply / Forward',
+        '(by watermark / In-Reply-To). Only actions of the matching `type` run, in',
+        'ascending `order` (lower first). filter_condition (encoded query) and',
+        'condition_script (JS boolean) gate each one. stop_processing=true halts the',
+        'chain so no higher-order action of the same type runs after it.',
+        '',
+        'TYPE drives what `current` is: type=new → a brand-new record of `table`',
+        '(REQUIRED for new); type=reply/forward → the watermarked record (table',
+        'usually empty). Inside `script` you also get `email`, `sys_email`, `event`,',
+        '`logger`, `classifier`, and `gs`.',
+        '',
+        'Idempotent: an existing action with the same name+table is returned unchanged.',
+      ].join('\n'),
+      inputSchema: InboundActionCreate,
+      annotations: {
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (input) => {
+      try {
+        const { name, type, table } = input;
+
+        if (type === 'new' && (table === undefined || table === '')) {
+          return errText(
+            'type=new requires a target `table` (the table the new `current` ' +
+              'record belongs to). Set `table` to an internal table name, e.g. ' +
+              "'incident'.",
+          );
+        }
+
+        const existing = await client.listRecords<{ sys_id: SnReference }>(
+          TABLE,
+          `name=${name}^table=${table ?? ''}`,
+          ['sys_id'],
+          1,
+        );
+        if (existing.length > 0) {
+          return textResult(
+            [
+              'Inbound email action already exists — skipped.',
+              '',
+              `name:   ${name}`,
+              `table:  ${table || '(none)'}`,
+              `sys_id: ${resolveValue(existing[0].sys_id)}`,
+            ].join('\n'),
+          );
+        }
+
+        const body = buildBody(input);
+        const record = await client.createRecord<SnRecord>(TABLE, body);
+        const sys_id = val(record, 'sys_id');
+
+        const lines = [
+          'Inbound email action created.',
+          '',
+          `name:            ${name}`,
+          `type:            ${type}`,
+          `action:          ${input.action}`,
+          `table:           ${table || '(resolved from watermark)'}`,
+          `order:           ${input.order ?? 100}`,
+          `stop_processing: ${input.stop_processing === true}`,
+          `sys_id:          ${sys_id}`,
+          `URL:             ${recordUrl(client, TABLE, sys_id)}`,
+        ];
+        const warnings = guardrails(input);
+        if (warnings.length) lines.push('', ...warnings);
+
+        return textResult(lines.join('\n'));
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  registry.registerTool(
+    'update_inbound_action',
+    {
+      access: 'write',
+      title: 'Update Inbound Email Action',
+      description: [
+        'Updates fields on an existing sysevent_in_email_action record.',
+        'Pass only the fields you want to change — omitted fields stay as-is.',
+        '',
+        'Reminder: type=new needs a target `table`; if you switch an action to',
+        'type=new make sure `table` is set or the action has nowhere to create a',
+        'record.',
+      ].join('\n'),
+      inputSchema: InboundActionUpdate,
+      annotations: {
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (input) => {
+      try {
+        const sys_id = input.sys_id as string;
+        const idErr = requireSysId(sys_id, 'sysevent_in_email_action sys_id');
+        if (idErr) return errText(idErr);
+
+        const body = buildBody(input);
+        if (Object.keys(body).length === 0) {
+          return textResult('No fields to update — all values were omitted.');
+        }
+
+        await client.patchRecord<unknown>(TABLE, sys_id, body);
+
+        const lines = [
+          'Inbound email action updated successfully.',
+          '',
+          `sys_id:         ${sys_id}`,
+          `Updated fields: ${Object.keys(body).join(', ')}`,
+        ];
+        // Only warn about table when the caller is actively setting type=new.
+        if (
+          input.type === 'new' &&
+          (input.table === undefined || input.table === '')
+        ) {
+          lines.push(
+            '',
+            'WARNING: type set to new without a `table` — verify the action has a ' +
+              'target table or it will have nowhere to create a record.',
+          );
+        }
+        const warnings = guardrails(input);
+        if (warnings.length) lines.push('', ...warnings);
+
+        return textResult(lines.join('\n'));
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  registry.registerTool(
+    'list_inbound_actions',
+    {
+      access: 'read',
+      title: 'List Inbound Email Actions',
+      description: [
+        'Lists sysevent_in_email_action records, optionally filtered by target',
+        'table, type (new/reply/forward), name substring, or active flag.',
+        'Ordered by type then order — the sequence in which they are evaluated.',
+      ].join('\n'),
+      inputSchema: InboundActionList,
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async ({ table, type, name_contains, active, limit }) => {
+      try {
+        const clauses: string[] = [];
+        if (table) clauses.push(`table=${table}`);
+        if (type) clauses.push(`type=${type}`);
+        if (name_contains) clauses.push(`nameLIKE${name_contains}`);
+        if (active !== undefined) clauses.push(`active=${String(active)}`);
+        clauses.push('ORDERBYtype', 'ORDERBYorder');
+
+        const rows = await client.listRecords<SnRecord>(
+          TABLE,
+          clauses.join('^'),
+          [
+            'sys_id',
+            'name',
+            'type',
+            'action',
+            'table',
+            'active',
+            'order',
+            'stop_processing',
+          ],
+          limit,
+        );
+
+        const summary = rows.length
+          ? rows
+              .map((r) => {
+                const act = val(r, 'active') === 'true' ? '' : ' (inactive)';
+                const stop =
+                  val(r, 'stop_processing') === 'true' ? ' — stops' : '';
+                const tbl = val(r, 'table') ? ` — ${val(r, 'table')}` : '';
+                return (
+                  `[${val(r, 'type')}] ${val(r, 'name')}${act}${tbl} ` +
+                  `— order ${val(r, 'order') || '100'}${stop} — ${val(r, 'sys_id')}`
+                );
+              })
+              .join('\n')
+          : 'No inbound email actions matched.';
+
+        return textResult(summary);
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  registry.registerTool(
+    'get_inbound_action',
+    {
+      access: 'read',
+      title: 'Get Inbound Email Action',
+      description: [
+        'Reads a single sysevent_in_email_action record: its classification, target',
+        'table, gating (filter_condition / condition_script), and server-side script.',
+      ].join('\n'),
+      inputSchema: InboundActionGet,
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async ({ sys_id }) => {
+      try {
+        const idErr = requireSysId(sys_id, 'sysevent_in_email_action sys_id');
+        if (idErr) return errText(idErr);
+
+        const base = await client.getRecord<SnRecord>(TABLE, sys_id);
+
+        const result = {
+          sys_id: val(base, 'sys_id'),
+          name: val(base, 'name'),
+          type: val(base, 'type'),
+          action: val(base, 'action'),
+          table: val(base, 'table'),
+          active: val(base, 'active') === 'true',
+          order: val(base, 'order') || '100',
+          stop_processing: val(base, 'stop_processing') === 'true',
+          event_name: val(base, 'event_name'),
+          from: disp(base, 'from'),
+          required_roles: val(base, 'required_roles'),
+          filter_condition: val(base, 'filter_condition'),
+          condition_script: val(base, 'condition_script'),
+          script: val(base, 'script'),
+          reply_email: val(base, 'reply_email'),
+          description: val(base, 'description'),
+          url: recordUrl(client, TABLE, sys_id),
+        };
+
+        const summary = [
+          `Inbound Email Action: ${result.name} (${result.sys_id})`,
+          `Type:      ${result.type} · action=${result.action}${
+            result.active ? '' : ' — INACTIVE'
+          }`,
+          `Target:    ${result.table || '(resolved from watermark)'}`,
+          `Order:     ${result.order}${
+            result.stop_processing ? ' · stops processing' : ''
+          }`,
+          `From:      ${result.from || '(any sender)'}`,
+          `Filter:    ${result.filter_condition || '(none)'}`,
+          `Condition: ${result.condition_script || '(none)'}`,
+          `Script:    ${result.script ? `${result.script.length} chars` : '(none)'}`,
+          `URL:       ${result.url}`,
+        ].join('\n');
+
+        return richResult(summary, result);
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+}

--- a/src/tools/inbound-actions/inbound-actions.ts
+++ b/src/tools/inbound-actions/inbound-actions.ts
@@ -8,6 +8,7 @@ import {
   requireSysId,
   resolveValue,
   richResult,
+  serializeFields,
   textResult,
   val,
 } from '../helpers.js';
@@ -23,18 +24,6 @@ import {
 const TABLE = 'sysevent_in_email_action';
 
 type InboundActionInput = Record<string, unknown>;
-
-/** Builds the Table API body from the supplied (already-defaulted) input. */
-function buildBody(input: InboundActionInput): InboundActionInput {
-  const body: InboundActionInput = {};
-  for (const f of INBOUND_ACTION_FIELDS) {
-    const v = input[f];
-    if (v === undefined) continue;
-    // The Table API takes strings; booleans and the numeric order serialise.
-    body[f] = typeof v === 'string' ? v : String(v);
-  }
-  return body;
-}
 
 /**
  * Type-specific guardrails shared by create and update. Returns the warning
@@ -117,7 +106,7 @@ export function registerInboundActionTools(
           );
         }
 
-        const body = buildBody(input);
+        const body = serializeFields(input, INBOUND_ACTION_FIELDS);
         const record = await client.createRecord<SnRecord>(TABLE, body);
         const sys_id = val(record, 'sys_id');
 
@@ -169,7 +158,7 @@ export function registerInboundActionTools(
         const idErr = requireSysId(sys_id, 'sysevent_in_email_action sys_id');
         if (idErr) return errText(idErr);
 
-        const body = buildBody(input);
+        const body = serializeFields(input, INBOUND_ACTION_FIELDS);
         if (Object.keys(body).length === 0) {
           return textResult('No fields to update — all values were omitted.');
         }

--- a/src/tools/inbound-actions/index.ts
+++ b/src/tools/inbound-actions/index.ts
@@ -1,0 +1,11 @@
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import type { ToolRegistry } from '../registry.js';
+import { registerInboundActionTools } from './inbound-actions.js';
+
+export function registerInboundActionsToolset(
+  registry: ToolRegistry,
+  client: ServiceNowClient,
+): void {
+  const scoped = registry.scoped('inbound-actions');
+  registerInboundActionTools(scoped, client);
+}

--- a/src/tools/inbound-actions/schemas.ts
+++ b/src/tools/inbound-actions/schemas.ts
@@ -1,0 +1,209 @@
+import { z } from 'zod';
+
+// ── Inbound Email Action (sysevent_in_email_action) ─────────────────────────
+//
+// An inbound email action runs server-side when ServiceNow receives an email.
+// Processing model (spell this out for the caller):
+//
+//   1. The inbound email is CLASSIFIED as New, Reply, or Forward — by watermark
+//      match / In-Reply-To headers. A watermarked reply to a notification is a
+//      Reply; an unmatched message is New.
+//   2. Only actions whose `type` matches the classification are considered.
+//   3. Matching actions run in ascending `order` (lower first). `filter_condition`
+//      (encoded query) and `condition_script` (JS boolean) gate each one.
+//   4. `stop_processing=true` halts the chain — no lower-priority action runs.
+//
+// Inside `script` the runtime exposes: `current` (the target/matched GlideRecord —
+// a NEW record of `table` for type=new, the watermarked record for reply/forward),
+// `email` (EmailWrapper: email.subject, email.body_text, email.origemail,
+// email.from, and custom `name: value` lines via email.body.<name>), `sys_email`
+// (the inbound sys_email GlideRecord), `event`, `logger`, `classifier`, and `gs`.
+//
+// Field shapes verified against the sysevent_in_email_action dictionary on the PDI.
+
+const InboundActionBase = z.object({
+  name: z
+    .string()
+    .min(1)
+    .describe('Name of the inbound email action, e.g. "Create Incident".'),
+  type: z
+    .enum(['new', 'reply', 'forward'])
+    .describe(
+      'Which class of inbound email this action handles — it runs ONLY for that ' +
+        'classification:\n' +
+        '• new — a fresh message with no watermark match (typically creates a record).\n' +
+        '• reply — a watermarked reply to a notification (`current` is the matched record).\n' +
+        '• forward — a forwarded message (`current` is the matched record).\n' +
+        'Pick exactly one; never assume one action covers all three.',
+    ),
+  action: z
+    .enum(['record_action', 'reply_email'])
+    .describe(
+      'What the action does:\n' +
+        '• record_action — run `script` against `current` (create/update a record). The common case.\n' +
+        '• reply_email — send the `reply_email` HTML body back to the sender instead.',
+    ),
+  table: z
+    .string()
+    .max(80)
+    .optional()
+    .describe(
+      "Target table internal name, e.g. 'incident' — NOT the label. For type=new " +
+        'this is the table the new `current` record belongs to and is REQUIRED. ' +
+        'For reply/forward the record is resolved from the watermark, so this is ' +
+        'usually left empty. Use resolve_table if unsure.',
+    ),
+  active: z
+    .boolean()
+    .optional()
+    .describe('Whether the action is active (eligible to run).'),
+  order: z
+    .number()
+    .int()
+    .optional()
+    .describe(
+      'Processing order among same-type actions. Lower runs first. Default 100.',
+    ),
+  stop_processing: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true, no lower-priority (higher-order) action of the same type runs ' +
+        'after this one. Use to claim an email exclusively. Default false.',
+    ),
+  filter_condition: z
+    .string()
+    .max(4000)
+    .optional()
+    .describe(
+      'DEFAULT FIELD for gating on record field values. Encoded query against ' +
+        "`table`, e.g. 'active=true^category=hardware'. For type=new it is matched " +
+        'against the new record; for reply/forward against the matched record. ' +
+        'Use this for field comparisons — never put them in condition_script.',
+    ),
+  condition_script: z
+    .string()
+    .max(254)
+    .optional()
+    .describe(
+      'Server-side JavaScript boolean expression deciding whether the action runs. ' +
+        'NOT an encoded query. Has access to `email`, `current`, and `gs`, e.g. ' +
+        '"email.subject.indexOf(\'urgent\') >= 0". Only use this when the gate ' +
+        'cannot be expressed as an encoded query (use filter_condition for those).',
+    ),
+  script: z
+    .string()
+    .max(8000)
+    .optional()
+    .describe(
+      'Server-side JavaScript run when action=record_action. Has `current` (the ' +
+        'target/matched GlideRecord), `email` (email.subject, email.body_text, ' +
+        'email.origemail, email.body.<custom>), `sys_email`, `event`, `logger`, ' +
+        '`classifier`, and `gs`. Call current.insert() for type=new or ' +
+        'current.update() for reply/forward to persist changes.',
+    ),
+  reply_email: z
+    .string()
+    .max(65536)
+    .optional()
+    .describe(
+      'HTML body sent back to the sender. Only used when action=reply_email.',
+    ),
+  from: z
+    .string()
+    .max(32)
+    .optional()
+    .describe(
+      'Optional sender filter: sys_id of a sys_user. When set, the action only ' +
+        'runs for emails from that user. Leave empty to match any sender. ' +
+        '(Subject/keyword filters are not a field — express them in condition_script.)',
+    ),
+  required_roles: z
+    .string()
+    .optional()
+    .describe(
+      'Optional comma-separated sys_user_role sys_ids the sending user must hold ' +
+        'for the action to run.',
+    ),
+  event_name: z
+    .string()
+    .max(40)
+    .optional()
+    .describe(
+      'System event that triggers this action. Defaults to "email.read" — leave ' +
+        'as the default unless you have a custom inbound email event.',
+    ),
+  description: z
+    .string()
+    .optional()
+    .describe(
+      'Free-text notes describing what the action does (not shown to users).',
+    ),
+});
+
+/**
+ * Every writable sysevent_in_email_action column, derived from the base schema so
+ * the schema stays the single source of truth — the create/update handlers iterate
+ * this to build the request body instead of re-listing field names. sys_id is
+ * intentionally absent: it addresses the record, it is never written into it.
+ */
+export const INBOUND_ACTION_FIELDS = Object.keys(InboundActionBase.shape);
+
+export const InboundActionCreate = InboundActionBase.extend({
+  type: InboundActionBase.shape.type
+    .default('new')
+    .describe(
+      'Which class of inbound email this action handles. Defaults to "new".',
+    ),
+  action: InboundActionBase.shape.action
+    .default('record_action')
+    .describe('What the action does. Defaults to "record_action".'),
+  active: z.boolean().optional().default(true).describe('Defaults to true.'),
+  order: z.number().int().optional().default(100).describe('Defaults to 100.'),
+  stop_processing: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe('Defaults to false.'),
+});
+
+export const InboundActionUpdate = InboundActionBase.partial().extend({
+  sys_id: z
+    .string()
+    .min(1)
+    .describe('sys_id of the sysevent_in_email_action record to update.'),
+});
+
+export const InboundActionList = z.object({
+  table: z
+    .string()
+    .optional()
+    .describe('Filter to actions targeting this table.'),
+  type: z
+    .enum(['new', 'reply', 'forward'])
+    .optional()
+    .describe('Filter by classification (new/reply/forward).'),
+  name_contains: z
+    .string()
+    .optional()
+    .describe('Filter to actions whose name contains this text.'),
+  active: z
+    .boolean()
+    .optional()
+    .describe('Filter by active flag. Omit to return both.'),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .default(50)
+    .describe('Maximum number of actions to return (1–100). Defaults to 50.'),
+});
+
+export const InboundActionGet = z.object({
+  sys_id: z
+    .string()
+    .min(1)
+    .describe('sys_id of the sysevent_in_email_action record to read.'),
+});

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -110,6 +110,10 @@ describe('tool inventory', () => {
           "access": "write",
           "group": "ui-policies",
         },
+        "create_inbound_action": {
+          "access": "write",
+          "group": "inbound-actions",
+        },
         "create_record": {
           "access": "write",
           "group": "records",
@@ -186,6 +190,10 @@ describe('tool inventory', () => {
           "access": "read",
           "group": "ui-policies",
         },
+        "get_inbound_action": {
+          "access": "read",
+          "group": "inbound-actions",
+        },
         "get_record": {
           "access": "read",
           "group": "records",
@@ -233,6 +241,10 @@ describe('tool inventory', () => {
         "list_form_ui_policies": {
           "access": "read",
           "group": "ui-policies",
+        },
+        "list_inbound_actions": {
+          "access": "read",
+          "group": "inbound-actions",
         },
         "list_scheduled_jobs": {
           "access": "read",
@@ -329,6 +341,10 @@ describe('tool inventory', () => {
         "update_form_ui_policy_rl_action": {
           "access": "write",
           "group": "ui-policies",
+        },
+        "update_inbound_action": {
+          "access": "write",
+          "group": "inbound-actions",
         },
         "update_record": {
           "access": "write",

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -37,6 +37,7 @@ export const TOOLSETS = [
   'client-scripts',
   'diagnostics',
   'events',
+  'inbound-actions',
   'records',
   'script-includes',
   'ui-actions',

--- a/src/tools/ui-actions/ui-actions.ts
+++ b/src/tools/ui-actions/ui-actions.ts
@@ -8,6 +8,7 @@ import {
   requireSysId,
   resolveValue,
   richResult,
+  serializeFields,
   textResult,
   val,
 } from '../helpers.js';
@@ -88,13 +89,7 @@ function buildBody(
   input: UiActionInput,
   toggle: boolean | undefined,
 ): UiActionInput {
-  const body: UiActionInput = {};
-  for (const f of UI_ACTION_FIELDS) {
-    const v = input[f];
-    if (v === undefined) continue;
-    // The Table API takes strings; booleans and the numeric order serialise.
-    body[f] = typeof v === 'string' ? v : String(v);
-  }
+  const body = serializeFields(input, UI_ACTION_FIELDS);
   // The toggle may have been forced on by the workspace guardrail.
   if (toggle !== undefined)
     body.format_for_configurable_workspace = String(toggle);


### PR DESCRIPTION
## What this changes

Adds an `inbound-actions` toolset for managing `sysevent_in_email_action` records (ServiceNow Inbound Email Actions) over the Table API. Four tools:

create_inbound_action / update_inbound_action — write tools covering type (new/reply/forward), target table, gating, server-side script, and reply email, with two guardrails: type=new requires a target table (hard error on create, warning on update — a New action has nowhere to create a record), and action=reply_email without a body warns.
list_inbound_actions — filter by table, type, name substring, or active flag; ordered by type then order (the evaluation sequence).
get_inbound_action — rich read of a single action (classification, target, filter_condition/condition_script gating, script).
Wired into buildServer() and the tool registry.

## How it was verified

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test` passing (381 tests; 14 colocated)
- [x] Exercised against a live ServiceNow PDI (for tool changes)

## Notes

Schema is the single source of truth: the request body is derived from `Object.keys(Base.shape)` and serialized by runtime type — no hand-maintained BOOL/STRING field lists (mirrors the ui-actions template).
filter_condition (encoded query) and condition_script (server-side JS boolean) are kept distinct, following the same convention as the business-rules domain.
type modeled as a strict enum with descriptions spelling out the processing model: emails are classified by watermark, only matching-type actions run in ascending order, and stop_processing halts the chain. For reply/forward, `current` is resolved from the watermark, so table is intentionally left empty.
New domain folder is self-contained (index.ts, schemas.ts, tool file, colocated test) and imports only helpers.ts, per the architecture rules.
