### PR TITLE
feat: add notifications toolset (email notifications + email scripts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Built and maintained by **Veldev** — an AI assistant for ServiceNow developers
 
 ## Features
 
-89 tools across 18 domains:
+97 tools across 19 domains:
 
 | Domain | What it covers |
 |---|---|
@@ -31,6 +31,7 @@ Built and maintained by **Veldev** — an AI assistant for ServiceNow developers
 | **Scheduled jobs** | Create, update, list, get, and run-now scheduled jobs (`sysauto`) — script executions, scheduled emails of reports, and template-based record generation |
 | **Events** | Register events (`sysevent_register`), create custom processing queues (`sysevent_queue`) and script actions (`sysevent_script_action`), fire events at runtime via `gs.eventQueue()`, and list/get any of them |
 | **Inbound email actions** | List, get, create, and update inbound email actions (`sysevent_in_email_action`) — server-side scripts that run when ServiceNow receives a New, Reply, or Forward email |
+| **Notifications** | List, get, create, and update email notifications (`sysevent_email_action`) — outbound mail rules triggered on insert/update or by an event — and reusable email scripts (`sys_script_email`) embedded in a body via `${mail_script:<name>}` (`create_notification`, `update_notification`, `list_notifications`, `get_notification`, `create_email_script`, `update_email_script`, `list_email_scripts`, `get_email_script`) |
 | **Generic Table CRUD** | Query, fetch, create, and update records in any ServiceNow table |
 | **ATF (Automated Test Framework)** | Create tests and suites, add and configure steps with cross-step output mapping, browse step configs and their input/output schemas |
 
@@ -316,7 +317,7 @@ For production self-hosting:
 In gateway mode (`CREDENTIAL_PROVIDER=header`) the server trusts two headers set by the proxy in front of it. They are only meaningful behind an authenticating proxy that sets them itself and strips any client-supplied values — never expose the server directly to clients with these headers enabled.
 
 - **`X-MCP-Access`** (security boundary) — per-request write grant. With `ACCESS_ENFORCEMENT=on`, a write tool call is denied unless the request carries this header with value `write` (default-deny, checked on every request).
-- **`X-MCP-Toolsets`** (UX, not security) — comma-separated toolset names (`atf`, `business-rules`, `catalog`, `client-scripts`, `diagnostics`, `events`, `inbound-actions`, `records`, `script-includes`, `ui-actions`, `ui-policies`, `update-sets`), read once from the session-creating request. Only the named toolsets' tools are registered for that session, trimming the tool list the model sees. Unknown names are ignored with a warning; if the header resolves to no known toolset, all toolsets register (fail-open). This filter never denies anything — write protection is `X-MCP-Access`'s job.
+- **`X-MCP-Toolsets`** (UX, not security) — comma-separated toolset names (`atf`, `business-rules`, `catalog`, `client-scripts`, `diagnostics`, `events`, `inbound-actions`, `notifications`, `records`, `script-includes`, `ui-actions`, `ui-policies`, `update-sets`), read once from the session-creating request. Only the named toolsets' tools are registered for that session, trimming the tool list the model sees. Unknown names are ignored with a warning; if the header resolves to no known toolset, all toolsets register (fail-open). This filter never denies anything — write protection is `X-MCP-Access`'s job.
 
 ---
 

--- a/biome.json
+++ b/biome.json
@@ -34,5 +34,17 @@
         "organizeImports": "on"
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["src/tools/notifications/**"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noTemplateCurlyInString": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import { registerClientScriptsTools } from './tools/client-scripts/index.js';
 import { registerDiagnosticsTools } from './tools/diagnostics/index.js';
 import { registerEventTools } from './tools/events/index.js';
 import { registerInboundActionsToolset } from './tools/inbound-actions/index.js';
+import { registerNotificationsToolset } from './tools/notifications/index.js';
 import { registerRecordTools } from './tools/records/index.js';
 import { ToolRegistry, type ToolRegistryOptions } from './tools/registry.js';
 import { registerScriptIncludesTools } from './tools/script-includes/index.js';
@@ -34,6 +35,7 @@ export function buildServer(
   registerAtfTools(registry, snClient);
   registerEventTools(registry, snClient);
   registerInboundActionsToolset(registry, snClient);
+  registerNotificationsToolset(registry, snClient);
   registerUiActionsToolset(registry, snClient);
   registerUiPolicyToolset(registry, snClient);
 

--- a/src/tools/notifications/email-scripts.test.ts
+++ b/src/tools/notifications/email-scripts.test.ts
@@ -1,0 +1,196 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import { SnApiError } from '../../clients/servicenow.js';
+import { buildTestPair, firstText } from '../../tests/helpers.js';
+import { registerEmailScriptTools } from './email-scripts.js';
+
+const EXISTING_SYS_ID = 'aaaa1111bbbb2222aaaa1111bbbb2222';
+const NEW_SYS_ID = 'cccc3333dddd4444cccc3333dddd4444';
+
+function ref(value: string, display = value) {
+  return { value, display_value: display };
+}
+
+function buildMockClient(): ServiceNowClient {
+  return {
+    listRecords: vi.fn().mockResolvedValue([]),
+    createRecord: vi.fn().mockResolvedValue({ sys_id: ref(NEW_SYS_ID) }),
+    patchRecord: vi.fn().mockResolvedValue({}),
+    getRecord: vi.fn().mockResolvedValue({
+      sys_id: ref(EXISTING_SYS_ID),
+      name: ref('incident_details'),
+      new_lines_to_html: ref('false'),
+      script: ref('template.print("hi");'),
+    }),
+    getInstanceUrl: vi.fn().mockReturnValue('https://pdi.service-now.com'),
+  } as unknown as ServiceNowClient;
+}
+
+describe('email-script tools (in-memory MCP)', () => {
+  let mcpClient: Client;
+  let teardown: () => Promise<void>;
+
+  beforeEach(async () => {
+    const pair = await buildTestPair(
+      registerEmailScriptTools,
+      buildMockClient(),
+    );
+    mcpClient = pair.mcpClient;
+    teardown = pair.teardown;
+  });
+
+  afterEach(async () => {
+    await teardown();
+  });
+
+  describe('create_email_script', () => {
+    it('creates a script and tells you the ${mail_script} token', async () => {
+      const result = await mcpClient.callTool({
+        name: 'create_email_script',
+        arguments: {
+          name: 'incident_details',
+          script:
+            '(function runMailScript(current, template){ template.print(current.number); })(current, template);',
+        },
+      });
+      const text = firstText(result);
+      expect(text).toContain('created');
+      expect(text).toContain(NEW_SYS_ID);
+      expect(text).toContain('${mail_script:incident_details}');
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('serialises new_lines_to_html default to a string', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerEmailScriptTools, mockClient);
+      try {
+        await pair.mcpClient.callTool({
+          name: 'create_email_script',
+          arguments: { name: 'foo', script: 'template.print("x");' },
+        });
+        expect(mockClient.createRecord).toHaveBeenCalledWith(
+          'sys_script_email',
+          expect.objectContaining({
+            name: 'foo',
+            script: 'template.print("x");',
+            new_lines_to_html: 'false',
+          }),
+        );
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('returns existing record without creating when name exists', async () => {
+      const idempotentClient = {
+        ...buildMockClient(),
+        listRecords: vi
+          .fn()
+          .mockResolvedValue([{ sys_id: ref(EXISTING_SYS_ID) }]),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(
+        registerEmailScriptTools,
+        idempotentClient,
+      );
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'create_email_script',
+          arguments: { name: 'incident_details' },
+        });
+        const text = firstText(result);
+        expect(text).toContain('already exists');
+        expect(idempotentClient.createRecord).not.toHaveBeenCalled();
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('surfaces SnApiError as isError with status in message', async () => {
+      const errorClient = {
+        ...buildMockClient(),
+        listRecords: vi
+          .fn()
+          .mockRejectedValue(
+            new SnApiError(500, 'Internal Server Error', 'fault', 'https://x'),
+          ),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(registerEmailScriptTools, errorClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'create_email_script',
+          arguments: { name: 'X' },
+        });
+        expect(result.isError).toBe(true);
+        expect(firstText(result)).toContain('500');
+      } finally {
+        await pair.teardown();
+      }
+    });
+  });
+
+  describe('update_email_script', () => {
+    it('patches the record and warns on rename', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_email_script',
+        arguments: { sys_id: EXISTING_SYS_ID, name: 'renamed_script' },
+      });
+      const text = firstText(result);
+      expect(text).toContain('updated successfully');
+      expect(text).toContain('${mail_script:renamed_script}');
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('returns isError when sys_id is not a valid hex id', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_email_script',
+        arguments: { sys_id: 'not-valid', name: 'x' },
+      });
+      expect(result.isError).toBe(true);
+      expect(firstText(result)).toContain('not a valid');
+    });
+
+    it('returns no-op message when only sys_id is provided', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_email_script',
+        arguments: { sys_id: EXISTING_SYS_ID },
+      });
+      expect(firstText(result)).toContain('No fields to update');
+    });
+  });
+
+  describe('list_email_scripts', () => {
+    it('returns a no-match message when nothing matches', async () => {
+      const result = await mcpClient.callTool({
+        name: 'list_email_scripts',
+        arguments: { name_contains: 'zzz' },
+      });
+      expect(firstText(result)).toContain('No email scripts matched');
+    });
+  });
+
+  describe('get_email_script', () => {
+    it('returns a two-block rich result with summary then JSON', async () => {
+      const result = (await mcpClient.callTool({
+        name: 'get_email_script',
+        arguments: { sys_id: EXISTING_SYS_ID },
+      })) as { content: Array<{ type: string; text: string }> };
+      expect(result.content).toHaveLength(2);
+      expect(result.content[0].text).toContain('Email Script');
+      expect(result.content[0].text).toContain(
+        '${mail_script:incident_details}',
+      );
+      const parsed = JSON.parse(result.content[1].text);
+      expect(parsed.sys_id).toBe(EXISTING_SYS_ID);
+      expect(parsed.name).toBe('incident_details');
+    });
+
+    it('returns isError when sys_id is not a valid hex id', async () => {
+      const result = await mcpClient.callTool({
+        name: 'get_email_script',
+        arguments: { sys_id: 'nope' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+});

--- a/src/tools/notifications/email-scripts.ts
+++ b/src/tools/notifications/email-scripts.ts
@@ -1,0 +1,240 @@
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import type { SnRecord, SnReference } from '../../types/servicenow.js';
+import {
+  errText,
+  handleError,
+  recordUrl,
+  requireSysId,
+  resolveValue,
+  richResult,
+  serializeFields,
+  textResult,
+  val,
+} from '../helpers.js';
+import type { ToolRegistrar } from '../registry.js';
+import {
+  EMAIL_SCRIPT_FIELDS,
+  EmailScriptCreate,
+  EmailScriptGet,
+  EmailScriptList,
+  EmailScriptUpdate,
+} from './schemas.js';
+
+const TABLE = 'sys_script_email';
+
+const RUNTIME_NOTE = [
+  'INVOCATION: embed in a notification/template body as ${mail_script:<name>}.',
+  'At send time ServiceNow runs the script and splices its printed output where',
+  'the token sits.',
+  '',
+  'OUTPUT: write with template.print("<html>...") — the return value is ignored.',
+  'IN SCOPE: current (target GlideRecord), template (TemplatePrinter), email',
+  '(EmailOutbound, e.g. email.addAddress), email_action, event (event.parm1/parm2), gs.',
+].join('\n');
+
+export function registerEmailScriptTools(
+  registry: ToolRegistrar,
+  client: ServiceNowClient,
+): void {
+  registry.registerTool(
+    'create_email_script',
+    {
+      access: 'write',
+      title: 'Create Email Script',
+      description: [
+        'Creates a sys_script_email record — a reusable mail script embedded in a',
+        'notification or email-template body via ${mail_script:<name>}.',
+        '',
+        RUNTIME_NOTE,
+        '',
+        'Wrap the body as:',
+        '(function runMailScript(current, template, email, email_action, event) {',
+        '  template.print("...");',
+        '})(current, template, email, email_action, event);',
+        '',
+        'Idempotent: an existing email script with the same name is returned unchanged.',
+      ].join('\n'),
+      inputSchema: EmailScriptCreate,
+      annotations: {
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (input) => {
+      try {
+        const { name } = input;
+
+        const existing = await client.listRecords<{ sys_id: SnReference }>(
+          TABLE,
+          `name=${name}`,
+          ['sys_id'],
+          1,
+        );
+        if (existing.length > 0) {
+          return textResult(
+            [
+              'Email script already exists — skipped.',
+              '',
+              `name:   ${name}`,
+              `sys_id: ${resolveValue(existing[0].sys_id)}`,
+            ].join('\n'),
+          );
+        }
+
+        const body = serializeFields(input, EMAIL_SCRIPT_FIELDS);
+        const record = await client.createRecord<SnRecord>(TABLE, body);
+        const sys_id = val(record, 'sys_id');
+
+        return textResult(
+          [
+            'Email script created.',
+            '',
+            `name:   ${name}`,
+            `sys_id: ${sys_id}`,
+            `URL:    ${recordUrl(client, TABLE, sys_id)}`,
+            '',
+            `Reference it from a notification body as \${mail_script:${name}}.`,
+          ].join('\n'),
+        );
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  registry.registerTool(
+    'update_email_script',
+    {
+      access: 'write',
+      title: 'Update Email Script',
+      description: [
+        'Updates fields on an existing sys_script_email record.',
+        'Pass only the fields you want to change — omitted fields stay as-is.',
+        '',
+        'Renaming changes the ${mail_script:<name>} token every referencing',
+        'notification/template body must use — update those bodies too.',
+      ].join('\n'),
+      inputSchema: EmailScriptUpdate,
+      annotations: {
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (input) => {
+      try {
+        const sys_id = input.sys_id as string;
+        const idErr = requireSysId(sys_id, 'sys_script_email sys_id');
+        if (idErr) return errText(idErr);
+
+        const body = serializeFields(input, EMAIL_SCRIPT_FIELDS);
+        if (Object.keys(body).length === 0) {
+          return textResult('No fields to update — all values were omitted.');
+        }
+
+        await client.patchRecord<unknown>(TABLE, sys_id, body);
+
+        const lines = [
+          'Email script updated successfully.',
+          '',
+          `sys_id:         ${sys_id}`,
+          `Updated fields: ${Object.keys(body).join(', ')}`,
+        ];
+        if (body.name !== undefined) {
+          lines.push(
+            '',
+            `Renamed — update any notification body referencing it to ` +
+              `\${mail_script:${body.name}}.`,
+          );
+        }
+
+        return textResult(lines.join('\n'));
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  registry.registerTool(
+    'list_email_scripts',
+    {
+      access: 'read',
+      title: 'List Email Scripts',
+      description: [
+        'Lists sys_script_email records, optionally filtered by name substring.',
+        'Use the name as the ${mail_script:<name>} token in a notification body.',
+      ].join('\n'),
+      inputSchema: EmailScriptList,
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async ({ name_contains, limit }) => {
+      try {
+        const clauses: string[] = [];
+        if (name_contains) clauses.push(`nameLIKE${name_contains}`);
+        clauses.push('ORDERBYname');
+
+        const rows = await client.listRecords<SnRecord>(
+          TABLE,
+          clauses.join('^'),
+          ['sys_id', 'name', 'new_lines_to_html'],
+          limit,
+        );
+
+        const summary = rows.length
+          ? rows
+              .map((r) => `${val(r, 'name')} — ${val(r, 'sys_id')}`)
+              .join('\n')
+          : 'No email scripts matched.';
+
+        return textResult(summary);
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  registry.registerTool(
+    'get_email_script',
+    {
+      access: 'read',
+      title: 'Get Email Script',
+      description: [
+        'Reads a single sys_script_email record: its name (the ${mail_script:<name>}',
+        'token) and the server-side script body that prints into the email.',
+      ].join('\n'),
+      inputSchema: EmailScriptGet,
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async ({ sys_id }) => {
+      try {
+        const idErr = requireSysId(sys_id, 'sys_script_email sys_id');
+        if (idErr) return errText(idErr);
+
+        const base = await client.getRecord<SnRecord>(TABLE, sys_id);
+
+        const result = {
+          sys_id: val(base, 'sys_id'),
+          name: val(base, 'name'),
+          new_lines_to_html: val(base, 'new_lines_to_html') === 'true',
+          script: val(base, 'script'),
+          url: recordUrl(client, TABLE, sys_id),
+        };
+
+        const summary = [
+          `Email Script: ${result.name} (${result.sys_id})`,
+          `Invoke as:    \${mail_script:${result.name}}`,
+          `Newlines→HTML: ${result.new_lines_to_html}`,
+          `Script:       ${
+            result.script ? `${result.script.length} chars` : '(none)'
+          }`,
+          `URL:          ${result.url}`,
+        ].join('\n');
+
+        return richResult(summary, result);
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+}

--- a/src/tools/notifications/index.ts
+++ b/src/tools/notifications/index.ts
@@ -1,0 +1,13 @@
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import type { ToolRegistry } from '../registry.js';
+import { registerEmailScriptTools } from './email-scripts.js';
+import { registerNotificationTools } from './notifications.js';
+
+export function registerNotificationsToolset(
+  registry: ToolRegistry,
+  client: ServiceNowClient,
+): void {
+  const scoped = registry.scoped('notifications');
+  registerNotificationTools(scoped, client);
+  registerEmailScriptTools(scoped, client);
+}

--- a/src/tools/notifications/notifications.test.ts
+++ b/src/tools/notifications/notifications.test.ts
@@ -1,0 +1,333 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import { SnApiError } from '../../clients/servicenow.js';
+import { buildTestPair, firstText } from '../../tests/helpers.js';
+import { registerNotificationTools } from './notifications.js';
+
+const EXISTING_SYS_ID = 'aaaa1111bbbb2222aaaa1111bbbb2222';
+const NEW_SYS_ID = 'cccc3333dddd4444cccc3333dddd4444';
+
+function ref(value: string, display = value) {
+  return { value, display_value: display };
+}
+
+function buildMockClient(): ServiceNowClient {
+  return {
+    listRecords: vi.fn().mockResolvedValue([]),
+    createRecord: vi.fn().mockResolvedValue({ sys_id: ref(NEW_SYS_ID) }),
+    patchRecord: vi.fn().mockResolvedValue({}),
+    getRecord: vi.fn().mockResolvedValue({
+      sys_id: ref(EXISTING_SYS_ID),
+      name: ref('Incident assigned to me'),
+      collection: ref('incident'),
+      active: ref('true'),
+      generation_type: ref('engine', 'Record inserted or updated'),
+      action_insert: ref('true'),
+      action_update: ref('false'),
+      condition: ref('active=true'),
+      advanced_condition: ref(''),
+      event_name: ref(''),
+      recipient_users: ref('abc123', 'Abel Tuter'),
+      recipient_groups: ref('', ''),
+      recipient_fields: ref('assigned_to'),
+      send_self: ref('false'),
+      event_parm_1: ref('false'),
+      event_parm_2: ref('false'),
+      subscribable: ref('false'),
+      subject: ref('Incident ${number} assigned'),
+      content_type: ref('text/html', 'HTML only'),
+      template: ref('', ''),
+      weight: ref('0'),
+      importance: ref(''),
+      mandatory: ref('false'),
+      category: ref('cat123', 'Uncategorized'),
+      digestable: ref('false'),
+      omit_watermark: ref('false'),
+      message_html: ref(
+        'Hi ${assigned_to.name} ${mail_script:incident_details}',
+      ),
+      description: ref(''),
+    }),
+    getInstanceUrl: vi.fn().mockReturnValue('https://pdi.service-now.com'),
+  } as unknown as ServiceNowClient;
+}
+
+describe('notification tools (in-memory MCP)', () => {
+  let mcpClient: Client;
+  let teardown: () => Promise<void>;
+
+  beforeEach(async () => {
+    const pair = await buildTestPair(
+      registerNotificationTools,
+      buildMockClient(),
+    );
+    mcpClient = pair.mcpClient;
+    teardown = pair.teardown;
+  });
+
+  afterEach(async () => {
+    await teardown();
+  });
+
+  describe('create_notification', () => {
+    it('creates an insert/update notification and returns its sys_id', async () => {
+      const result = await mcpClient.callTool({
+        name: 'create_notification',
+        arguments: {
+          name: 'Incident assigned to me',
+          collection: 'incident',
+          action_insert: true,
+          recipient_fields: 'assigned_to',
+          subject: 'Incident assigned',
+          message_html: '<p>You have a new incident.</p>',
+        },
+      });
+      const text = firstText(result);
+      expect(text).toContain('created');
+      expect(text).toContain(NEW_SYS_ID);
+      expect(text).toContain('on insert');
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('serialises booleans/numbers to strings and applies defaults', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerNotificationTools, mockClient);
+      try {
+        await pair.mcpClient.callTool({
+          name: 'create_notification',
+          arguments: {
+            name: 'My Notif',
+            collection: 'incident',
+            action_update: true,
+            weight: 5,
+            recipient_users: 'abc123',
+          },
+        });
+        expect(mockClient.createRecord).toHaveBeenCalledWith(
+          'sysevent_email_action',
+          expect.objectContaining({
+            name: 'My Notif',
+            collection: 'incident',
+            generation_type: 'engine',
+            active: 'true',
+            action_insert: 'false',
+            action_update: 'true',
+            send_self: 'true',
+            content_type: 'text/html',
+            weight: '5',
+          }),
+        );
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('GUARDRAIL: rejects generation_type=engine without a collection', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerNotificationTools, mockClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'create_notification',
+          arguments: { name: 'No Table', action_insert: true },
+        });
+        expect(result.isError).toBe(true);
+        expect(firstText(result)).toContain('requires a `collection`');
+        expect(mockClient.createRecord).not.toHaveBeenCalled();
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('GUARDRAIL: warns when engine notification has no insert/update trigger', async () => {
+      const result = await mcpClient.callTool({
+        name: 'create_notification',
+        arguments: {
+          name: 'Never fires',
+          collection: 'incident',
+          recipient_users: 'abc123',
+        },
+      });
+      const text = firstText(result);
+      expect(text).toContain('never fire');
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('GUARDRAIL: warns when event notification has no event_name', async () => {
+      const result = await mcpClient.callTool({
+        name: 'create_notification',
+        arguments: {
+          name: 'Eventless',
+          generation_type: 'event',
+          recipient_users: 'abc123',
+        },
+      });
+      expect(firstText(result)).toContain('never fire');
+    });
+
+    it('GUARDRAIL: warns when no recipient source is set', async () => {
+      const result = await mcpClient.callTool({
+        name: 'create_notification',
+        arguments: {
+          name: 'Nobody',
+          collection: 'incident',
+          action_insert: true,
+          send_self: false,
+        },
+      });
+      const text = firstText(result);
+      expect(text).toContain('send to nobody');
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('flags referenced ${mail_script:<name>} bodies', async () => {
+      const result = await mcpClient.callTool({
+        name: 'create_notification',
+        arguments: {
+          name: 'With script',
+          collection: 'incident',
+          action_insert: true,
+          send_self: true,
+          message_html: 'Hi ${mail_script:incident_details}',
+        },
+      });
+      const text = firstText(result);
+      expect(text).toContain('incident_details');
+      expect(text).toContain('email scripts');
+    });
+
+    it('returns existing record without creating when name+collection exists', async () => {
+      const idempotentClient = {
+        ...buildMockClient(),
+        listRecords: vi
+          .fn()
+          .mockResolvedValue([{ sys_id: ref(EXISTING_SYS_ID) }]),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(
+        registerNotificationTools,
+        idempotentClient,
+      );
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'create_notification',
+          arguments: {
+            name: 'Incident assigned to me',
+            collection: 'incident',
+            action_insert: true,
+          },
+        });
+        const text = firstText(result);
+        expect(text).toContain('already exists');
+        expect(text).toContain(EXISTING_SYS_ID);
+        expect(idempotentClient.createRecord).not.toHaveBeenCalled();
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('surfaces SnApiError as isError with status in message', async () => {
+      const errorClient = {
+        ...buildMockClient(),
+        listRecords: vi
+          .fn()
+          .mockRejectedValue(
+            new SnApiError(500, 'Internal Server Error', 'fault', 'https://x'),
+          ),
+      } as unknown as ServiceNowClient;
+      const pair = await buildTestPair(registerNotificationTools, errorClient);
+      try {
+        const result = await pair.mcpClient.callTool({
+          name: 'create_notification',
+          arguments: { name: 'X', collection: 'incident', action_insert: true },
+        });
+        expect(result.isError).toBe(true);
+        expect(firstText(result)).toContain('500');
+      } finally {
+        await pair.teardown();
+      }
+    });
+  });
+
+  describe('update_notification', () => {
+    it('patches the record and lists updated fields', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_notification',
+        arguments: { sys_id: EXISTING_SYS_ID, active: false, weight: 10 },
+      });
+      const text = firstText(result);
+      expect(text).toContain('updated successfully');
+      expect(text).toContain(EXISTING_SYS_ID);
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('serialises the boolean to a string', async () => {
+      const mockClient = buildMockClient();
+      const pair = await buildTestPair(registerNotificationTools, mockClient);
+      try {
+        await pair.mcpClient.callTool({
+          name: 'update_notification',
+          arguments: { sys_id: EXISTING_SYS_ID, omit_watermark: true },
+        });
+        expect(mockClient.patchRecord).toHaveBeenCalledWith(
+          'sysevent_email_action',
+          EXISTING_SYS_ID,
+          expect.objectContaining({ omit_watermark: 'true' }),
+        );
+      } finally {
+        await pair.teardown();
+      }
+    });
+
+    it('returns isError when sys_id is not a valid hex id', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_notification',
+        arguments: { sys_id: 'not-valid', name: 'x' },
+      });
+      expect(result.isError).toBe(true);
+      expect(firstText(result)).toContain('not a valid');
+    });
+
+    it('returns no-op message when only sys_id is provided', async () => {
+      const result = await mcpClient.callTool({
+        name: 'update_notification',
+        arguments: { sys_id: EXISTING_SYS_ID },
+      });
+      expect(firstText(result)).toContain('No fields to update');
+    });
+  });
+
+  describe('list_notifications', () => {
+    it('returns a no-match message when nothing matches', async () => {
+      const result = await mcpClient.callTool({
+        name: 'list_notifications',
+        arguments: { collection: 'incident' },
+      });
+      expect(firstText(result)).toContain('No email notifications matched');
+    });
+  });
+
+  describe('get_notification', () => {
+    it('returns a two-block rich result with summary then JSON', async () => {
+      const result = (await mcpClient.callTool({
+        name: 'get_notification',
+        arguments: { sys_id: EXISTING_SYS_ID },
+      })) as { content: Array<{ type: string; text: string }> };
+      expect(result.content).toHaveLength(2);
+      expect(result.content[0].text).toContain('Email Notification');
+      const parsed = JSON.parse(result.content[1].text);
+      expect(parsed.sys_id).toBe(EXISTING_SYS_ID);
+      expect(parsed.generation_type).toBe('engine');
+      expect(parsed.action_insert).toBe(true);
+      expect(parsed.recipient_users).toBe('Abel Tuter');
+      expect(parsed.mail_script_refs).toContain('incident_details');
+    });
+
+    it('returns isError when sys_id is not a valid hex id', async () => {
+      const result = await mcpClient.callTool({
+        name: 'get_notification',
+        arguments: { sys_id: 'nope' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+});

--- a/src/tools/notifications/notifications.ts
+++ b/src/tools/notifications/notifications.ts
@@ -1,0 +1,460 @@
+import type { ServiceNowClient } from '../../clients/servicenow.js';
+import type { SnRecord, SnReference } from '../../types/servicenow.js';
+import {
+  disp,
+  errText,
+  handleError,
+  recordUrl,
+  requireSysId,
+  resolveValue,
+  richResult,
+  serializeFields,
+  textResult,
+  val,
+} from '../helpers.js';
+import type { ToolRegistrar } from '../registry.js';
+import {
+  NOTIFICATION_FIELDS,
+  NotificationCreate,
+  NotificationGet,
+  NotificationList,
+  NotificationUpdate,
+} from './schemas.js';
+
+const TABLE = 'sysevent_email_action';
+
+type NotificationInput = Record<string, unknown>;
+
+const MAIL_SCRIPT_RE = /\$\{mail_script:([^}]+)\}/g;
+
+/** Unique sys_script_email names referenced via ${mail_script:<name>} in a body. */
+function mailScriptRefs(...bodies: string[]): string[] {
+  const names = new Set<string>();
+  for (const body of bodies) {
+    for (const m of body.matchAll(MAIL_SCRIPT_RE)) {
+      const name = m[1].trim();
+      if (name) names.add(name);
+    }
+  }
+  return [...names];
+}
+
+/**
+ * Create-time guardrails: a notification with full known state (defaults
+ * applied) that would never fire or reach no one. Returns warning lines to
+ * append (empty when nothing to flag).
+ */
+function guardrails(input: NotificationInput): string[] {
+  const warnings: string[] = [];
+  const gen = (input.generation_type as string) ?? 'engine';
+
+  if (
+    gen === 'engine' &&
+    input.action_insert !== true &&
+    input.action_update !== true
+  ) {
+    warnings.push(
+      'WARNING: generation_type=engine but neither action_insert nor ' +
+        'action_update is set — this notification will never fire. Enable at ' +
+        'least one, or switch to an event/triggered notification.',
+    );
+  }
+  if (gen === 'event' && !input.event_name) {
+    warnings.push(
+      'WARNING: generation_type=event but no event_name is set — this ' +
+        'notification will never fire. Set the system event that triggers it.',
+    );
+  }
+
+  const hasRecipient =
+    !!input.recipient_users ||
+    !!input.recipient_groups ||
+    !!input.recipient_fields ||
+    input.send_self === true ||
+    input.event_parm_1 === true ||
+    input.event_parm_2 === true;
+  if (!hasRecipient) {
+    warnings.push(
+      'WARNING: no recipient source set (no recipient_users, recipient_groups, ' +
+        'recipient_fields, send_self, or event parm) — this notification would ' +
+        'send to nobody.',
+    );
+  }
+
+  return warnings;
+}
+
+export function registerNotificationTools(
+  registry: ToolRegistrar,
+  client: ServiceNowClient,
+): void {
+  registry.registerTool(
+    'create_notification',
+    {
+      access: 'write',
+      title: 'Create Email Notification',
+      description: [
+        'Creates a sysevent_email_action record — an OUTBOUND email rule that',
+        'sends mail when something happens to a record. (Inbound counterpart:',
+        'create_inbound_action.)',
+        '',
+        'WHEN it sends — generation_type:',
+        '• engine — Record inserted or updated: fires on writes to `collection`,',
+        '  gated by action_insert/action_update and `condition` (encoded query) /',
+        '  `advanced_condition` (server-side JS). `collection` is REQUIRED here.',
+        '• event — fires when system `event_name` is pushed to the event queue.',
+        '• triggered — sent explicitly from Flow Designer / notification scripts.',
+        '',
+        'WHO receives it is the UNION of recipient_users, recipient_groups,',
+        'recipient_fields (user/group fields on the record), send_self, and event',
+        'parm recipients.',
+        '',
+        'WHAT it sends — `subject` + `message_html`. Both resolve ${field} and',
+        '${mail_script:<name>} substitutions; ${mail_script:<name>} embeds a',
+        'sys_script_email record (create_email_script).',
+        '',
+        'WEIGHT de-dupes notifications firing together for the same record+recipient:',
+        'among non-zero weights only the highest sends; weight 0 (default) always sends.',
+        '',
+        'Idempotent: an existing notification with the same name+collection is returned unchanged.',
+      ].join('\n'),
+      inputSchema: NotificationCreate,
+      annotations: {
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (input) => {
+      try {
+        const { name, collection, generation_type } = input;
+
+        if (generation_type === 'engine' && !collection) {
+          return errText(
+            'generation_type=engine requires a `collection` (the table whose ' +
+              'inserts/updates trigger the notification). Set `collection` to an ' +
+              "internal table name, e.g. 'incident'.",
+          );
+        }
+
+        const existing = await client.listRecords<{ sys_id: SnReference }>(
+          TABLE,
+          `name=${name}^collection=${collection ?? ''}`,
+          ['sys_id'],
+          1,
+        );
+        if (existing.length > 0) {
+          return textResult(
+            [
+              'Email notification already exists — skipped.',
+              '',
+              `name:       ${name}`,
+              `collection: ${collection || '(none)'}`,
+              `sys_id:     ${resolveValue(existing[0].sys_id)}`,
+            ].join('\n'),
+          );
+        }
+
+        const body = serializeFields(input, NOTIFICATION_FIELDS);
+        const record = await client.createRecord<SnRecord>(TABLE, body);
+        const sys_id = val(record, 'sys_id');
+
+        const lines = [
+          'Email notification created.',
+          '',
+          `name:            ${name}`,
+          `collection:      ${collection || '(none)'}`,
+          `generation_type: ${generation_type}`,
+          `triggers:        ${triggerSummary(input)}`,
+          `recipients:      ${recipientSummary(input)}`,
+          `weight:          ${input.weight ?? 0}`,
+          `sys_id:          ${sys_id}`,
+          `URL:             ${recordUrl(client, TABLE, sys_id)}`,
+        ];
+
+        const refs = mailScriptRefs(
+          (input.message_html as string) ?? '',
+          (input.subject as string) ?? '',
+        );
+        if (refs.length) {
+          lines.push(
+            '',
+            `References email scripts (${refs.join(', ')}) — ensure each ` +
+              'sys_script_email exists (create_email_script).',
+          );
+        }
+
+        const warnings = guardrails(input);
+        if (warnings.length) lines.push('', ...warnings);
+
+        return textResult(lines.join('\n'));
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  registry.registerTool(
+    'update_notification',
+    {
+      access: 'write',
+      title: 'Update Email Notification',
+      description: [
+        'Updates fields on an existing sysevent_email_action record.',
+        'Pass only the fields you want to change — omitted fields stay as-is.',
+        '',
+        'Reminder: an engine notification needs action_insert/action_update set,',
+        'an event notification needs event_name, and at least one recipient source',
+        'must be present or it sends to nobody.',
+      ].join('\n'),
+      inputSchema: NotificationUpdate,
+      annotations: {
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (input) => {
+      try {
+        const sys_id = input.sys_id as string;
+        const idErr = requireSysId(sys_id, 'sysevent_email_action sys_id');
+        if (idErr) return errText(idErr);
+
+        const body = serializeFields(input, NOTIFICATION_FIELDS);
+        if (Object.keys(body).length === 0) {
+          return textResult('No fields to update — all values were omitted.');
+        }
+
+        await client.patchRecord<unknown>(TABLE, sys_id, body);
+
+        const lines = [
+          'Email notification updated successfully.',
+          '',
+          `sys_id:         ${sys_id}`,
+          `Updated fields: ${Object.keys(body).join(', ')}`,
+        ];
+
+        const refs = mailScriptRefs(
+          (input.message_html as string) ?? '',
+          (input.subject as string) ?? '',
+        );
+        if (refs.length) {
+          lines.push(
+            '',
+            `References email scripts (${refs.join(', ')}) — ensure each ` +
+              'sys_script_email exists (create_email_script).',
+          );
+        }
+
+        return textResult(lines.join('\n'));
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  registry.registerTool(
+    'list_notifications',
+    {
+      access: 'read',
+      title: 'List Email Notifications',
+      description: [
+        'Lists sysevent_email_action records, optionally filtered by target table',
+        '(collection), generation_type (engine/event/triggered), name substring, or',
+        'active flag. Ordered by collection then name.',
+      ].join('\n'),
+      inputSchema: NotificationList,
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async ({ collection, generation_type, name_contains, active, limit }) => {
+      try {
+        const clauses: string[] = [];
+        if (collection) clauses.push(`collection=${collection}`);
+        if (generation_type) clauses.push(`generation_type=${generation_type}`);
+        if (name_contains) clauses.push(`nameLIKE${name_contains}`);
+        if (active !== undefined) clauses.push(`active=${String(active)}`);
+        clauses.push('ORDERBYcollection', 'ORDERBYname');
+
+        const rows = await client.listRecords<SnRecord>(
+          TABLE,
+          clauses.join('^'),
+          [
+            'sys_id',
+            'name',
+            'collection',
+            'generation_type',
+            'event_name',
+            'action_insert',
+            'action_update',
+            'active',
+            'weight',
+          ],
+          limit,
+        );
+
+        const summary = rows.length
+          ? rows
+              .map((r) => {
+                const act = val(r, 'active') === 'true' ? '' : ' (inactive)';
+                const tbl = val(r, 'collection')
+                  ? ` — ${val(r, 'collection')}`
+                  : '';
+                const trig = listTrigger(r);
+                const wt = val(r, 'weight');
+                const weight = wt && wt !== '0' ? ` — weight ${wt}` : '';
+                return (
+                  `[${val(r, 'generation_type') || 'engine'}] ${val(r, 'name')}` +
+                  `${act}${tbl} — ${trig}${weight} — ${val(r, 'sys_id')}`
+                );
+              })
+              .join('\n')
+          : 'No email notifications matched.';
+
+        return textResult(summary);
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  registry.registerTool(
+    'get_notification',
+    {
+      access: 'read',
+      title: 'Get Email Notification',
+      description: [
+        'Reads a single sysevent_email_action record: its trigger (generation_type,',
+        'insert/update, condition / advanced_condition, event_name), recipients,',
+        'subject/body, and delivery settings. Also lists the email scripts the body',
+        'references via ${mail_script:<name>}.',
+      ].join('\n'),
+      inputSchema: NotificationGet,
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async ({ sys_id }) => {
+      try {
+        const idErr = requireSysId(sys_id, 'sysevent_email_action sys_id');
+        if (idErr) return errText(idErr);
+
+        const base = await client.getRecord<SnRecord>(TABLE, sys_id);
+        const message_html = val(base, 'message_html');
+        const subject = val(base, 'subject');
+
+        const result = {
+          sys_id: val(base, 'sys_id'),
+          name: val(base, 'name'),
+          collection: val(base, 'collection'),
+          active: val(base, 'active') === 'true',
+          generation_type: val(base, 'generation_type') || 'engine',
+          action_insert: val(base, 'action_insert') === 'true',
+          action_update: val(base, 'action_update') === 'true',
+          condition: val(base, 'condition'),
+          advanced_condition: val(base, 'advanced_condition'),
+          event_name: val(base, 'event_name'),
+          recipient_users: disp(base, 'recipient_users'),
+          recipient_groups: disp(base, 'recipient_groups'),
+          recipient_fields: val(base, 'recipient_fields'),
+          send_self: val(base, 'send_self') === 'true',
+          event_parm_1: val(base, 'event_parm_1') === 'true',
+          event_parm_2: val(base, 'event_parm_2') === 'true',
+          subscribable: val(base, 'subscribable') === 'true',
+          subject,
+          content_type: val(base, 'content_type'),
+          template: disp(base, 'template'),
+          weight: val(base, 'weight') || '0',
+          importance: val(base, 'importance'),
+          mandatory: val(base, 'mandatory') === 'true',
+          category: disp(base, 'category'),
+          digestable: val(base, 'digestable') === 'true',
+          omit_watermark: val(base, 'omit_watermark') === 'true',
+          message_html,
+          mail_script_refs: mailScriptRefs(message_html, subject),
+          description: val(base, 'description'),
+          url: recordUrl(client, TABLE, sys_id),
+        };
+
+        const summary = [
+          `Email Notification: ${result.name} (${result.sys_id})`,
+          `Table:      ${result.collection || '(none)'}${
+            result.active ? '' : ' — INACTIVE'
+          }`,
+          `Trigger:    ${triggerSummary(result)}`,
+          `Condition:  ${result.condition || '(none)'}`,
+          `Advanced:   ${result.advanced_condition ? 'yes (script)' : '(none)'}`,
+          `Recipients: ${recipientSummary(result)}`,
+          `Subject:    ${result.subject || '(none)'}`,
+          `Body:       ${
+            result.message_html
+              ? `${result.message_html.length} chars`
+              : '(none)'
+          }`,
+          `Weight:     ${result.weight}${
+            result.omit_watermark ? ' · watermark omitted' : ''
+          }`,
+          `Mail scripts: ${
+            result.mail_script_refs.length
+              ? result.mail_script_refs.join(', ')
+              : '(none)'
+          }`,
+          `URL:        ${result.url}`,
+        ].join('\n');
+
+        return richResult(summary, result);
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+}
+
+/** One-line trigger description from a tool input or a get() result object. */
+function triggerSummary(r: {
+  generation_type?: string;
+  action_insert?: unknown;
+  action_update?: unknown;
+  event_name?: string;
+}): string {
+  const gen = r.generation_type ?? 'engine';
+  if (gen === 'engine') {
+    const ops: string[] = [];
+    if (r.action_insert === true) ops.push('insert');
+    if (r.action_update === true) ops.push('update');
+    return ops.length
+      ? `on ${ops.join(' / ')}`
+      : 'engine — no insert/update set';
+  }
+  if (gen === 'event') {
+    return r.event_name ? `event ${r.event_name}` : 'event — no event_name set';
+  }
+  return 'triggered (Flow/script)';
+}
+
+/** Trigger summary from a raw list row (string-valued reference fields). */
+function listTrigger(r: SnRecord): string {
+  const gen = val(r, 'generation_type') || 'engine';
+  if (gen === 'event') return `event ${val(r, 'event_name') || '(unset)'}`;
+  if (gen === 'triggered') return 'triggered';
+  const ops: string[] = [];
+  if (val(r, 'action_insert') === 'true') ops.push('insert');
+  if (val(r, 'action_update') === 'true') ops.push('update');
+  return ops.length ? `on ${ops.join('/')}` : 'no insert/update';
+}
+
+/** One-line recipient description from a tool input or a get() result object. */
+function recipientSummary(r: {
+  recipient_users?: unknown;
+  recipient_groups?: unknown;
+  recipient_fields?: unknown;
+  send_self?: unknown;
+  event_parm_1?: unknown;
+  event_parm_2?: unknown;
+}): string {
+  const sources: string[] = [];
+  if (r.recipient_users) sources.push('users');
+  if (r.recipient_groups) sources.push('groups');
+  if (r.recipient_fields) sources.push('record fields');
+  if (r.send_self === true) sources.push('event creator');
+  if (r.event_parm_1 === true) sources.push('event parm1');
+  if (r.event_parm_2 === true) sources.push('event parm2');
+  return sources.length ? sources.join(', ') : '(none — sends to nobody)';
+}

--- a/src/tools/notifications/schemas.ts
+++ b/src/tools/notifications/schemas.ts
@@ -1,0 +1,440 @@
+import { z } from 'zod';
+
+// ── Email Notification (sysevent_email_action) ──────────────────────────────
+//
+// An email notification is an OUTBOUND mail rule: when something happens to a
+// record, ServiceNow composes and sends an email. It is the counterpart to an
+// inbound email action (mail in → inbound action; mail out → notification).
+//
+// WHEN it sends — driven by `generation_type` ("Send when"):
+//   • engine  — "Record inserted or updated": fires on DB writes to `collection`
+//               gated by `action_insert` / `action_update` and `condition`
+//               (an encoded query) / `advanced_condition` (server-side JS).
+//   • event   — "Event is fired": fires when the named system `event_name` is
+//               pushed to the event queue (e.g. by a business rule via
+//               gs.eventQueue). `collection` is the event's table.
+//   • triggered — sent explicitly from Flow Designer / sn_notification scripts.
+//
+// WHO receives it — recipients are the UNION of every source set:
+//   recipient_users, recipient_groups, recipient_fields (user/group fields ON
+//   the record), send_self ("send to event creator"), and event parm 1/2 when
+//   those flags say the parm carries a recipient. exclude_delegates trims
+//   delegates from the resolved list.
+//
+// WHAT it sends — `subject` + `message_html` (the body). Both resolve
+//   `${field}` and `${mail_script:<name>}` substitutions at send time;
+//   `${mail_script:<name>}` embeds the output of a sys_script_email record
+//   (see EmailScript schemas below). `content_type` picks HTML/plain/both;
+//   `template` points at an Email Template (sysevent_email_template).
+//
+// DELIVERY knobs — `weight` de-dupes notifications that fire together for the
+//   same record+recipient (see field doc); `importance`, `from`, `reply_to`,
+//   `mandatory`, `category`. Outbound notifications stamp a WATERMARK so
+//   recipient replies thread back to the source record via inbound actions;
+//   `omit_watermark` suppresses it.
+//
+// Field shapes verified against the sysevent_email_action dictionary on the PDI.
+
+export const CONTENT_TYPES = [
+  'text/html',
+  'multipart/mixed',
+  'text/plain',
+  'text/xml',
+] as const;
+
+export const GENERATION_TYPES = ['engine', 'event', 'triggered'] as const;
+
+const NotificationBase = z.object({
+  name: z
+    .string()
+    .min(1)
+    .describe('Name of the notification, e.g. "Incident assigned to me".'),
+  collection: z
+    .string()
+    .max(80)
+    .optional()
+    .describe(
+      "Internal table name the notification is for, e.g. 'incident' — NOT the " +
+        'label. REQUIRED when generation_type=engine (the table whose inserts/' +
+        'updates are watched and that `condition` queries). For event-based ' +
+        "notifications it is the event's table. Use resolve_table if unsure.",
+    ),
+  active: z
+    .boolean()
+    .optional()
+    .describe('Whether the notification is active (eligible to send).'),
+  description: z
+    .string()
+    .optional()
+    .describe('Free-text notes describing the notification (internal only).'),
+
+  // ── WHEN to send ──────────────────────────────────────────────────────────
+  generation_type: z
+    .enum(GENERATION_TYPES)
+    .optional()
+    .describe(
+      'How the notification is triggered ("Send when"):\n' +
+        '• engine — Record inserted or updated: fires on DB writes to `collection`, gated by action_insert/action_update + condition.\n' +
+        '• event — Event is fired: fires when system `event_name` is pushed to the event queue.\n' +
+        '• triggered — sent explicitly from Flow Designer / notification scripts.\n' +
+        'Default engine.',
+    ),
+  action_insert: z
+    .boolean()
+    .optional()
+    .describe(
+      'When generation_type=engine, fire on record INSERT. Ignored for event/triggered.',
+    ),
+  action_update: z
+    .boolean()
+    .optional()
+    .describe(
+      'When generation_type=engine, fire on record UPDATE. Ignored for event/triggered.',
+    ),
+  condition: z
+    .string()
+    .max(8000)
+    .optional()
+    .describe(
+      'DEFAULT FIELD for gating on record field values. Encoded query against ' +
+        "`collection`, e.g. 'priority=1^active=true'. Use VALCHANGES / CHANGESTO " +
+        'for change-based gating. NEVER put field comparisons in ' +
+        'advanced_condition — put them here.',
+    ),
+  advanced_condition: z
+    .string()
+    .max(8000)
+    .optional()
+    .describe(
+      'Server-side JavaScript boolean expression — only for logic that CANNOT be ' +
+        'expressed as an encoded query (e.g. gs.* calls). NOT an encoded query. ' +
+        'Has access to `current`, `event`, and `gs`. Use `condition` for plain ' +
+        'field comparisons.',
+    ),
+  event_name: z
+    .string()
+    .max(40)
+    .optional()
+    .describe(
+      'System event that triggers this notification when generation_type=event, ' +
+        "e.g. 'incident.assigned'. The event must be registered (sysevent_register) " +
+        'and pushed via gs.eventQueue(...). Ignored when generation_type=engine.',
+    ),
+
+  // ── WHO receives it (union of all sources) ─────────────────────────────────
+  recipient_users: z
+    .string()
+    .optional()
+    .describe(
+      'Comma-separated sys_user sys_ids to always send to (the "Users" list).',
+    ),
+  recipient_groups: z
+    .string()
+    .optional()
+    .describe(
+      'Comma-separated sys_user_group sys_ids whose members receive it (the "Groups" list).',
+    ),
+  recipient_fields: z
+    .string()
+    .optional()
+    .describe(
+      'Comma-separated FIELD NAMES on `collection` that hold a user or group ' +
+        "(e.g. 'assigned_to,caller_id') — their value at send time becomes a " +
+        'recipient. This is the "Users/Groups in fields" field.',
+    ),
+  send_self: z
+    .boolean()
+    .optional()
+    .describe(
+      'Send to the event creator / the user who triggered the record change ' +
+        '("Send to event creator"). Defaults to true in ServiceNow.',
+    ),
+  event_parm_1: z
+    .boolean()
+    .optional()
+    .describe(
+      'Treat event parm1 as a recipient (sys_id passed as the 2nd arg of ' +
+        'gs.eventQueue). Only meaningful for event-based notifications.',
+    ),
+  event_parm_2: z
+    .boolean()
+    .optional()
+    .describe(
+      'Treat event parm2 as a recipient (3rd arg of gs.eventQueue). ' +
+        'Only meaningful for event-based notifications.',
+    ),
+  exclude_delegates: z
+    .boolean()
+    .optional()
+    .describe('Exclude delegates of the resolved recipients from delivery.'),
+  subscribable: z
+    .boolean()
+    .optional()
+    .describe(
+      'Allow users to subscribe to this notification (adds subscription-based recipients).',
+    ),
+
+  // ── WHAT it sends ───────────────────────────────────────────────────────────
+  subject: z
+    .string()
+    .max(100)
+    .optional()
+    .describe(
+      'Email subject line. Supports ${field} and ${mail_script:<name>} substitutions.',
+    ),
+  message_html: z
+    .string()
+    .max(4000)
+    .optional()
+    .describe(
+      'The notification BODY (HTML). Resolves ${field} substitutions (dot-walk ' +
+        'allowed, e.g. ${caller_id.name}) and ${mail_script:<name>} — which embeds ' +
+        'the output of the sys_script_email record named <name> (create one with ' +
+        'create_email_script). Use this as the primary content field.',
+    ),
+  content_type: z
+    .enum(CONTENT_TYPES)
+    .optional()
+    .describe(
+      'Body format: text/html (default), multipart/mixed (HTML + plain text), ' +
+        'text/plain, or text/xml.',
+    ),
+  template: z
+    .string()
+    .max(32)
+    .optional()
+    .describe(
+      'Optional sys_id of an Email Template (sysevent_email_template) supplying ' +
+        'subject/body. Leave empty to use the inline subject/message_html.',
+    ),
+
+  // ── DELIVERY knobs ───────────────────────────────────────────────────────────
+  weight: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe(
+      'De-duplicates notifications that fire together for the SAME record and ' +
+        'recipient. Among those with a NON-ZERO weight, only the highest sends ' +
+        '(ties at the top all send). Weight 0 (default) ALWAYS sends, regardless ' +
+        'of others. Raise the weight of the more specific notification to suppress ' +
+        'a generic one.',
+    ),
+  importance: z
+    .enum(['high', 'low'])
+    .optional()
+    .describe(
+      'Optional email priority header: high or low. Omit for normal importance.',
+    ),
+  from: z
+    .string()
+    .max(100)
+    .optional()
+    .describe(
+      'Optional From address override. Leave empty for the instance default.',
+    ),
+  reply_to: z
+    .string()
+    .max(100)
+    .optional()
+    .describe('Optional Reply-To address override.'),
+  mandatory: z
+    .boolean()
+    .optional()
+    .describe(
+      'Mark as mandatory — recipients cannot unsubscribe and it ignores ' +
+        'notification preferences. Use sparingly.',
+    ),
+  category: z
+    .string()
+    .max(32)
+    .optional()
+    .describe(
+      'Optional sys_id of a Notification Category (sys_notification_category). ' +
+        'Omit to let ServiceNow apply the default category.',
+    ),
+  digestable: z
+    .boolean()
+    .optional()
+    .describe('Allow this notification to be included in digest emails.'),
+  omit_watermark: z
+    .boolean()
+    .optional()
+    .describe(
+      'Suppress the outbound WATERMARK. By default notifications stamp a ' +
+        'watermark so recipient replies thread back to the source record via ' +
+        'inbound email actions; set true to send an unwatermarked email.',
+    ),
+});
+
+/**
+ * Every writable sysevent_email_action column this tool exposes, derived from
+ * the base schema so the schema stays the single source of truth — the
+ * create/update handlers iterate this (via serializeFields) to build the
+ * request body instead of re-listing field names. sys_id is intentionally
+ * absent: it addresses the record, it is never written into it.
+ */
+export const NOTIFICATION_FIELDS = Object.keys(NotificationBase.shape);
+
+export const NotificationCreate = NotificationBase.extend({
+  active: z.boolean().optional().default(true).describe('Defaults to true.'),
+  generation_type: NotificationBase.shape.generation_type
+    .unwrap()
+    .default('engine')
+    .describe(
+      'How the notification is triggered. Defaults to engine (Record inserted or updated).',
+    ),
+  action_insert: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe('Fire on record insert (engine only). Defaults to false.'),
+  action_update: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe('Fire on record update (engine only). Defaults to false.'),
+  send_self: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe(
+      'Send to the event creator. Defaults to true (matches ServiceNow).',
+    ),
+  content_type: NotificationBase.shape.content_type
+    .unwrap()
+    .default('text/html')
+    .describe('Body format. Defaults to text/html.'),
+});
+
+export const NotificationUpdate = NotificationBase.partial().extend({
+  sys_id: z
+    .string()
+    .min(1)
+    .describe('sys_id of the sysevent_email_action record to update.'),
+});
+
+export const NotificationList = z.object({
+  collection: z
+    .string()
+    .optional()
+    .describe('Filter to notifications for this table (internal name).'),
+  generation_type: z
+    .enum(GENERATION_TYPES)
+    .optional()
+    .describe('Filter by trigger type (engine/event/triggered).'),
+  name_contains: z
+    .string()
+    .optional()
+    .describe('Filter to notifications whose name contains this text.'),
+  active: z
+    .boolean()
+    .optional()
+    .describe('Filter by active flag. Omit to return both.'),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .default(50)
+    .describe(
+      'Maximum number of notifications to return (1–100). Defaults to 50.',
+    ),
+});
+
+export const NotificationGet = z.object({
+  sys_id: z
+    .string()
+    .min(1)
+    .describe('sys_id of the sysevent_email_action record to read.'),
+});
+
+// ── Email Script (sys_script_email) ─────────────────────────────────────────
+//
+// A reusable mail script. It exists ONLY to be embedded in a notification or
+// email-template body via ${mail_script:<name>} — at send time ServiceNow runs
+// the script and splices its printed output into the email where the token sits.
+//
+// The script body is the standard wrapper:
+//   (function runMailScript(current, template, email, email_action, event) { ... })
+//       (current, template, email, email_action, event);
+// In scope (verified against OOB scripts on the PDI):
+//   • current      — GlideRecord being notified about (the target record).
+//   • template     — TemplatePrinter; WRITE OUTPUT with template.print('<html>').
+//   • email        — outbound EmailOutbound; e.g. email.addAddress('bcc', addr, name).
+//   • email_action — the sysevent_email_action GlideRecord sending the mail.
+//   • event        — the triggering event GlideRecord (event.parm1 / event.parm2).
+//   • gs           — GlideSystem (globally available).
+// Output is produced by template.print(...), NOT by returning a value.
+
+const EmailScriptBase = z.object({
+  name: z
+    .string()
+    .min(1)
+    .max(100)
+    .describe(
+      'Unique name of the mail script. Reference it from a notification/template ' +
+        'body as ${mail_script:<name>}. Conventionally lower_snake_case.',
+    ),
+  script: z
+    .string()
+    .max(4000)
+    .optional()
+    .describe(
+      'Server-side JavaScript wrapped as ' +
+        '"(function runMailScript(current, template, email, email_action, event){ ... })' +
+        '(current, template, email, email_action, event);". Write into the email ' +
+        "with template.print('<html>...') — the script's RETURN VALUE is ignored. " +
+        'In scope: current (target GlideRecord), template (TemplatePrinter), email ' +
+        '(EmailOutbound), email_action, event (event.parm1/parm2), and gs.',
+    ),
+  new_lines_to_html: z
+    .boolean()
+    .optional()
+    .describe(
+      'Convert newline characters in printed output to <br/> tags. Defaults to false.',
+    ),
+});
+
+export const EMAIL_SCRIPT_FIELDS = Object.keys(EmailScriptBase.shape);
+
+export const EmailScriptCreate = EmailScriptBase.extend({
+  new_lines_to_html: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe('Convert newlines to <br/> tags. Defaults to false.'),
+});
+
+export const EmailScriptUpdate = EmailScriptBase.partial().extend({
+  sys_id: z
+    .string()
+    .min(1)
+    .describe('sys_id of the sys_script_email record to update.'),
+});
+
+export const EmailScriptList = z.object({
+  name_contains: z
+    .string()
+    .optional()
+    .describe('Filter to email scripts whose name contains this text.'),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .default(50)
+    .describe(
+      'Maximum number of email scripts to return (1–100). Defaults to 50.',
+    ),
+});
+
+export const EmailScriptGet = z.object({
+  sys_id: z
+    .string()
+    .min(1)
+    .describe('sys_id of the sys_script_email record to read.'),
+});

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -86,6 +86,10 @@ describe('tool inventory', () => {
           "access": "write",
           "group": "client-scripts",
         },
+        "create_email_script": {
+          "access": "write",
+          "group": "notifications",
+        },
         "create_event_queue": {
           "access": "write",
           "group": "events",
@@ -113,6 +117,10 @@ describe('tool inventory', () => {
         "create_inbound_action": {
           "access": "write",
           "group": "inbound-actions",
+        },
+        "create_notification": {
+          "access": "write",
+          "group": "notifications",
         },
         "create_record": {
           "access": "write",
@@ -182,6 +190,10 @@ describe('tool inventory', () => {
           "access": "read",
           "group": "update-sets",
         },
+        "get_email_script": {
+          "access": "read",
+          "group": "notifications",
+        },
         "get_event": {
           "access": "read",
           "group": "events",
@@ -193,6 +205,10 @@ describe('tool inventory', () => {
         "get_inbound_action": {
           "access": "read",
           "group": "inbound-actions",
+        },
+        "get_notification": {
+          "access": "read",
+          "group": "notifications",
         },
         "get_record": {
           "access": "read",
@@ -226,6 +242,10 @@ describe('tool inventory', () => {
           "access": "read",
           "group": "catalog",
         },
+        "list_email_scripts": {
+          "access": "read",
+          "group": "notifications",
+        },
         "list_event_queues": {
           "access": "read",
           "group": "events",
@@ -245,6 +265,10 @@ describe('tool inventory', () => {
         "list_inbound_actions": {
           "access": "read",
           "group": "inbound-actions",
+        },
+        "list_notifications": {
+          "access": "read",
+          "group": "notifications",
         },
         "list_scheduled_jobs": {
           "access": "read",
@@ -318,6 +342,10 @@ describe('tool inventory', () => {
           "access": "write",
           "group": "client-scripts",
         },
+        "update_email_script": {
+          "access": "write",
+          "group": "notifications",
+        },
         "update_event_queue": {
           "access": "write",
           "group": "events",
@@ -345,6 +373,10 @@ describe('tool inventory', () => {
         "update_inbound_action": {
           "access": "write",
           "group": "inbound-actions",
+        },
+        "update_notification": {
+          "access": "write",
+          "group": "notifications",
         },
         "update_record": {
           "access": "write",

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -38,6 +38,7 @@ export const TOOLSETS = [
   'diagnostics',
   'events',
   'inbound-actions',
+  'notifications',
   'records',
   'script-includes',
   'ui-actions',


### PR DESCRIPTION
## What this changes

Adds a new `notifications` tool domain — the outbound side of ServiceNow's email cycle and the counterpart to the existing `inbound-actions` domain (mail in → inbound action; mail out → notification).

**Email Notifications (`sysevent_email_action`)** — `create_notification`, `update_notification`, `list_notifications`, `get_notification`:
- WHEN: `generation_type` = engine (insert/update) vs event vs triggered, with `condition` (encoded query) kept distinct from `advanced_condition` (server-side JS), same convention as business-rules.
- WHO: union of `recipient_users`, `recipient_groups`, `recipient_fields`, `send_self`, and event-parm recipients.
- WHAT: `subject` + `message_html`, resolving `${field}` and `${mail_script:<name>}` substitutions.
- Delivery: `weight` (de-dupes notifications firing for the same record+recipient), `importance`, `omit_watermark`, etc.

**Email Scripts (`sys_script_email`)** — `create_email_script`, `update_email_script`, `list_email_scripts`, `get_email_script`: reusable mail scripts embedded in a body via `${mail_script:<name>}`, printing into the email with `template.print(...)`.

Follows the established conventions: schema-derived request bodies (`Object.keys(Base.shape)` + `serializeFields`), shared helpers (`resolveDisplay`/`val`/`handleError`/`richResult`/`textResult`/`recordUrl`/`requireSysId`), rich reads return two blocks, writes one. Guardrails: engine notifications require a `collection` and warn when nothing triggers them; warn when no recipient source is set. `get_notification` surfaces the `${mail_script:<name>}` references found in the body, linking the two concepts.

Wired into `buildServer()` and the registry `TOOLSETS` array.

Closes #

## How it was verified

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (0 warnings)
- [x] `npm test` passing (407 tests; 26 new across the two colocated test files; tool-inventory snapshot updated)
- [x] Exercised against a live ServiceNow PDI: created an event-triggered and an insert/update-triggered notification, an email script referenced from a notification body, and confirmed each guardrail (engine-without-collection rejection, never-fires warnings, no-recipient warning). Output shapes verified — no raw `{ value, display_value }`, no `undefined`/`null` in strings.

## Notes

- `biome.json` scopes `suspicious/noTemplateCurlyInString` **off** for `src/tools/notifications/**`. That folder legitimately documents ServiceNow's literal `${field}` / `${mail_script:<name>}` substitution syntax in tool/field descriptions (the text the model reads), so the rule is a false positive there; it stays active for the rest of the repo.
- README bumped to **97 tools across 19 domains**, with the new domain row and `notifications` added to the `X-MCP-Toolsets` list.
- Follow-up idea (not in scope): tools/helpers don't validate the HTML body — `message_html` is persisted verbatim, by design.